### PR TITLE
ansible: add --setup-adtrust to ipa installation

### DIFF
--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -5,9 +5,11 @@
     alias install-ipa="/usr/sbin/ipa-server-install --unattended \
       --realm={{ service.ipa.domain | upper | quote }}           \
       --domain={{ service.ipa.domain | quote }}                  \
+      --netbios-name={{ service.ipa.netbios | quote }}           \
       --ds-password={{ service.ipa.password | quote }}           \
       --admin-password={{ service.ipa.password | quote }}        \
       --setup-dns                                                \
+      --setup-adtrust                                            \
       --auto-forwarders                                          \
       --auto-reverse                                             \
       --no-dnssec-validation                                     \
@@ -59,13 +61,6 @@
     stdin: |
       {{ service.ipa.password }}
       {{ service.ipa.password }}
-
-- name: Install IPA-AD trust
-  shell: |
-    /usr/sbin/ipa-adtrust-install --unattended                 \
-      --netbios-name={{ service.ipa.netbios | quote }}         \
-      --admin-password={{ service.ipa.password | quote }}      \
-      --add-sids
 
 - name: 'Setup trust with {{ service.samba.domain }}'
   shell: |


### PR DESCRIPTION
This removes the need to do this step explictily.

This also fix the following error on Fedora 34:

```
 fatal: [ipa]: FAILED! => changed=true
  cmd: |-
    kinit admin
    ipa trust-add samba.test --admin Administrator --password
  delta: '0:00:01.131665'
  end: '2022-04-12 02:57:30.557983'
  msg: non-zero return code
  rc: 1
  start: '2022-04-12 02:57:29.426318'
  stderr: 'ipa: ERROR: CIFS server communication error: code "3221225564", message "An attempt has been made to operate on an impersonation token by a thread that is not currently impersonating a client." (both may be "None")'
  stderr_lines: <omitted>
  stdout: 'Password for admin@IPA.TEST: '
  stdout_lines: <omitted>
```

This error could be also fixed by restarting krb5kdc after
ipa-adtrust-install. But avoiding this step completely is better.
