### PR TITLE
samba: fix ACL on sudoRole object class

### DIFF
--- a/src/ansible/roles/samba/files/sudo.class.ldif
+++ b/src/ansible/roles/samba/files/sudo.class.ldif
@@ -23,4 +23,4 @@ mayContain: sudoNotAfter
 mayContain: description
 possSuperiors: top
 defaultObjectCategory: CN=sudoRole,CN=Schema,CN=Configuration,dc=samba,dc=test
-
+defaultSecurityDescriptor: D:(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;SY)(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;DA)(OA;;CCDC;bf967a86-0de6-11d0-a285-00aa003049e2;;AO)(OA;;CCDC;bf967aba-0de6-11d0-a285-00aa003049e2;;AO)(OA;;CCDC;bf967a9c-0de6-11d0-a285-00aa003049e2;;AO)(OA;;CCDC;bf967aa8-0de6-11d0-a285-00aa003049e2;;PO)(A;;RPLCLORC;;;AU)(A;;LCRPLORC;;;ED)(OA;;CCDC;4828CC14-1437-45bc-9B07-AD6F015E5F28;;AO)


### PR DESCRIPTION
sudoRole objects are now readable by Authenticated Users.