### PR TITLE
ipa: remove auto.master and auto.direct autofs maps

### DIFF
--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -32,6 +32,14 @@
   args:
     creates: /etc/ipa/default.conf
 
+- name: Remove auto.master and auto.direct maps
+  shell: |
+    kinit admin
+    ipa automountmap-del default auto.master
+    ipa automountmap-del default auto.direct
+  args:
+    stdin: '{{ service.ipa.password }}'
+
 - name: Create pw-never-expires group
   shell: |
     kinit admin


### PR DESCRIPTION
By removing these maps we get empty initial state consistent to what
we have in other providers. This will simplify testing of autofs using
parametrized topology.