### PR TITLE
compose: add SYS_CHROOT capability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     cap_add:
     - NET_RAW
     - NET_ADMIN
+    - SYS_CHROOT
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -28,6 +29,7 @@ services:
     - SYS_ADMIN
     - SYS_PTRACE
     - AUDIT_WRITE
+    - SYS_CHROOT
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -46,6 +48,7 @@ services:
     cap_add:
     - SYS_PTRACE
     - AUDIT_WRITE
+    - SYS_CHROOT
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -65,6 +68,7 @@ services:
     - SYS_ADMIN
     - SYS_PTRACE
     - AUDIT_WRITE
+    - SYS_CHROOT
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -86,6 +90,7 @@ services:
     - NET_RAW
     - NET_ADMIN
     - AUDIT_WRITE
+    - SYS_CHROOT
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -106,6 +111,7 @@ services:
     - SYS_ADMIN
     - SYS_PTRACE
     - AUDIT_WRITE
+    - SYS_CHROOT
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -126,6 +132,7 @@ services:
     - SYS_ADMIN
     - SYS_PTRACE
     - AUDIT_WRITE
+    - SYS_CHROOT
     security_opt:
     - apparmor=unconfined
     - label=disable


### PR DESCRIPTION
ssh connections are failing due to:
fatal: chroot("/usr/share/empty.sshd"): Operation not permitted [preauth]

Adding SYS_CHROOT capability fixes the problem. This solution is based on https://access.redhat.com/solutions/3626531

Unfortunately I don't have time to investigate the issue more profoundly. I don't know why the problem appeared now and it was working correctly before. If you don't like the solution, take this patch as a problem report and provide a better fix.