### PR TITLE
Network: Fix iPAM option validation error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,3 +148,5 @@ networks:
      config:
        - subnet: 172.16.100.0/24
          gateway: 172.16.100.1
+     options:
+        driver: host-local


### PR DESCRIPTION
Fixes the error:

ERROR: Network "sssd-ci" needs to be recreated - IPAM option "driver" has changed