### PR TITLE
actions: retry start of containers upon failure

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,32 @@
+name: Actions
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'actions/**'
+  pull_request:
+    paths:
+    - 'actions/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup containers
+      uses: ./actions/setup
+      with:
+        path: sssd-ci-containers
+
+    - name: Exec in containers
+      uses: ./actions/exec
+      with:
+        working-directory: /
+        script: ls

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -64,8 +64,13 @@ runs:
       docker-compose --project-directory "${{ inputs.path }}" config
 
   - name: Start containers
-    shell: bash
-    run: |
+    uses: nick-fields/retry@v2
+    with:
+      shell: bash
+      max_attempts: 3
+      timeout_minutes: 5
+      retry_on: error
+      command: |
         sudo make -C "${{ inputs.path }}" up         \
           DOCKER_HOST=unix:///run/podman/podman.sock \
           LIMIT="${{ inputs.limit }}"                \


### PR DESCRIPTION
There is a race condition in podman that was fixed in v4 which is
not yet available in current ubuntu github runners.

```
ERROR: for client  Cannot start service client: error configuring network namespace for container 8d66f2cf911f87e75a2f54759808c68be3ef13088d427af04ecfe4392f025180: error adding pod client_client to CNI network "sssd-ci": running [/usr
```

This change should mitigate that.