### PR TITLE
fedora: install e2fsprogs

### DIFF
--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -172,6 +172,13 @@
       - xml-core
       - xsltproc
 
+  - name: Install packages required for multihost tests
+    apt:
+      state: present
+      update_cache: yes
+      name:
+      - e2fsprogs
+
   - name: Install additional python packages
     pip:
       name:

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -170,6 +170,12 @@
       - uid_wrapper
       - valgrind
 
+  - name: Install packages required for multihost tests
+    dnf:
+      state: present
+      name:
+      - e2fsprogs
+
   - name: Install additional python packages
     pip:
       name:

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -170,6 +170,13 @@
       - xml-core
       - xsltproc
 
+  - name: Install packages required for multihost tests
+    apt:
+      state: present
+      update_cache: yes
+      name:
+      - e2fsprogs
+
   - name: Install additional python packages
     pip:
       name:


### PR DESCRIPTION
https://github.com/SSSD/sssd/commit/c6db359fa8b75ed0d03b7211c588e8c317d80c26 added a new dependency for the multihost tests to the chattr command, which is provided by the e2fsprogs package.