### PR TITLE
packages: install e2fsprogs in base_ground

### DIFF
--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -8,6 +8,7 @@
       - bash-completion
       - bind9utils
       - dbus
+      - e2fsprogs
       - expect
       - findutils
       - gdb
@@ -171,13 +172,6 @@
       - valgrind
       - xml-core
       - xsltproc
-
-  - name: Install packages required for multihost tests
-    apt:
-      state: present
-      update_cache: yes
-      name:
-      - e2fsprogs
 
   - name: Install additional python packages
     pip:

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -21,6 +21,7 @@
       - bind-utils
       - dbus-tools
       - dnf-plugins-core
+      - e2fsprogs
       - expect
       - findutils
       - gdb
@@ -169,12 +170,6 @@
       - rpm-build
       - uid_wrapper
       - valgrind
-
-  - name: Install packages required for multihost tests
-    dnf:
-      state: present
-      name:
-      - e2fsprogs
 
   - name: Install additional python packages
     pip:

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -8,6 +8,7 @@
       - bash-completion
       - bind9utils
       - dbus
+      - e2fsprogs
       - expect
       - findutils
       - gdb
@@ -169,13 +170,6 @@
       - valgrind
       - xml-core
       - xsltproc
-
-  - name: Install packages required for multihost tests
-    apt:
-      state: present
-      update_cache: yes
-      name:
-      - e2fsprogs
 
   - name: Install additional python packages
     pip:


### PR DESCRIPTION
9e2203a6d3d1b20cd3347a621574f2b4da52bdb9 installed it in the client image only, but it is needed in all images.