### PR TITLE
actions: put down containers before starting them to allow retry

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -71,6 +71,11 @@ runs:
       timeout_minutes: 5
       retry_on: error
       command: |
+        # Put it down first to allow smooth retry and avoid "network need to be recreated" issue
+        # This is a workaround for older podman
+        sudo make -C "${{ inputs.path }}" down         \
+          DOCKER_HOST=unix:///run/podman/podman.sock
+
         sudo make -C "${{ inputs.path }}" up         \
           DOCKER_HOST=unix:///run/podman/podman.sock \
           LIMIT="${{ inputs.limit }}"                \


### PR DESCRIPTION
Older podman has a race condition which sometimes ends up in failure
when starting containers so we added a retry to mitigate it. However,
when we retry it, it refuses to retry and trows "network must be
recreated" which is also an issue with older podman. This change
mitigates that.