### PR TITLE
ansible: add firewalld

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
     - SYS_PTRACE
     - AUDIT_WRITE
     - SYS_CHROOT
+    - NET_ADMIN
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -70,6 +71,7 @@ services:
     - SYS_PTRACE
     - AUDIT_WRITE
     - SYS_CHROOT
+    - NET_ADMIN
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -113,6 +115,7 @@ services:
     - SYS_PTRACE
     - AUDIT_WRITE
     - SYS_CHROOT
+    - NET_ADMIN
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -134,6 +137,7 @@ services:
     - SYS_PTRACE
     - AUDIT_WRITE
     - SYS_CHROOT
+    - NET_ADMIN
     security_opt:
     - apparmor=unconfined
     - label=disable

--- a/src/ansible/playbook_image_service.yml
+++ b/src/ansible/playbook_image_service.yml
@@ -3,6 +3,7 @@
   gather_facts: yes
   roles:
   - facts
+  - firewall
 
 - hosts: master.ldap.test
   gather_facts: no

--- a/src/ansible/roles/firewall/tasks/main.yml
+++ b/src/ansible/roles/firewall/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: Start firewalld
+  service:
+    name: firewalld
+    enabled: yes
+    state: started
+
+- name: Set default firewalld zone to trusted
+  shell: |
+    firewall-cmd --set-default-zone=trusted

--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -11,6 +11,7 @@
       - e2fsprogs
       - expect
       - findutils
+      - firewalld
       - gdb
       - gdbserver
       - git

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -24,6 +24,7 @@
       - e2fsprogs
       - expect
       - findutils
+      - firewalld
       - gdb
       - gdb-gdbserver
       - gh

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -11,6 +11,7 @@
       - e2fsprogs
       - expect
       - findutils
+      - firewalld
       - gdb
       - gdbserver
       - git


### PR DESCRIPTION
We set the default zone to trusted so all incomming communication is
allowed. We can then just block specific ports in CI to simulate
unreachable servers with rich rules, for example:

```
firewall-cmd --add-rich-rule 'rule service name=ldap reject'
```