### PR TITLE
action: do not install packages in setup

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -26,7 +26,7 @@ runs:
     run: |
       set -ex
       sudo apt-get update
-      sudo apt-get install -y podman docker-compose
+      sudo apt-get install -y podman=3.4.3 docker-compose
       sudo systemctl enable --now podman.socket
 
   - name: Checkout sssd-ci-containers repository


### PR DESCRIPTION
There is a regression in podman that fails to create networks. The
workaround is to avoid update of the podman package. We can skip
the installation since both podman and docker-compose are available
in the base image.

See: https://github.com/actions/runner-images/issues/7753