### PR TITLE
fix: Add defaut value for extended_packageset, fix renamed skip_addc_…

### DIFF
--- a/src/ansible/group_vars/all
+++ b/src/ansible/group_vars/all
@@ -73,3 +73,4 @@ join_ldap: yes
 join_ad: no
 trust_ipa_samba: yes
 trust_ipa_ad: no
+extended_packageset: yes

--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -11,6 +11,7 @@
     passkey_support: "{{ override_passkey_support | default('no') | bool }}"
     user_regular_uid: 1024
     ansible_become: yes
+    extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
 
 - name: Include services
   ansible.builtin.import_playbook: playbook_image_service.yml
@@ -22,8 +23,9 @@
     join_ldap: "{{ override_join_ldap | default('yes') | bool }}"
     join_samba: "{{ override_join_samba | default('yes') | bool }}"
     join_ipa: "{{ override_join_ipa | default('yes') | bool }}"
+    extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
 
 - hosts: ad
   gather_facts: yes
   roles:
-  - { role: ad, skip_install: yes, skip_dns: yes, ad_permanent_users: ['Administrator'] }
+  - { role: ad, skip_addc_install: yes, skip_dns: yes, ad_permanent_users: ['Administrator'] }


### PR DESCRIPTION
The variable extended_packageset did not have a default value resulting in failure when it was not in idmci metadata.
Issue did not manifest for containers as the variable is in the inventory.
Variable skip_addc_install was not renamed in all places.