### PR TITLE
passkey: add arc4random_buf() to random.so

### DIFF
--- a/src/ansible/roles/passkey/files/random.c
+++ b/src/ansible/roles/passkey/files/random.c
@@ -141,6 +141,12 @@ RAND_bytes (unsigned char *buf, int num)
     return 1;
 }
 
+void __attribute__ ((visibility ("protected")))
+arc4random_buf(void *buf, size_t nbytes)
+{
+	memset (buf, 0x1, nbytes);
+}
+
 static void __attribute__((constructor))
 install_mock_provider(void)
 {


### PR DESCRIPTION
Fedora started providing arc4random_buf(), so libfido2 switched and
started using this random generator provider. I'm adding a simple mock
for this function so that QE can continue their work.