### PR TITLE
provision: Add krb5.conf for realm join

### DIFF
--- a/src/ansible/roles/client/tasks/main.yml
+++ b/src/ansible/roles/client/tasks/main.yml
@@ -55,6 +55,14 @@
       path:  /enrollment/samba.keytab
     register: enrollment_samba_1
 
+  - name: Create /etc/krb5.conf for samba join
+    template:
+      src: krb5.conf
+      dest: /etc/krb5.conf
+      owner: root
+      group: root
+      mode: 0644
+
   - name: Realm join Samba domain
     command: realm join {{ service.samba.domain | quote }} --verbose
     args:
@@ -101,6 +109,14 @@
     stat:
       path:  /enrollment/ad.keytab
     register: enrollment_ad_1
+
+  - name: Create /etc/krb5.conf for AD join
+    template:
+      src: krb5.conf
+      dest: /etc/krb5.conf
+      owner: root
+      group: root
+      mode: 0644
 
   - name: Join AD domain
     command: realm join {{ service.ad.domain | quote }} --verbose


### PR DESCRIPTION
We need krb5.conf  with rdns = false for realm join to work properly in environment where reverse dns records are different that internal names.