### PR TITLE
Broken network plugin

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -11,9 +11,9 @@ runs:
       sudo apt-get install -y podman docker-compose
 
       # Workaround https://github.com/actions/runner-images/issues/7753
-      curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-1_amd64.deb
-      sudo dpkg -i containernetworking-plugins_1.1.1+ds1-1_amd64.deb
-      rm --force containernetworking-plugins_1.1.1+ds1-1_amd64.deb
+      curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+      sudo dpkg -i containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+      rm --force containernetworking-plugins_1.1.1+ds1-3_amd64.deb
 
   - name: Enable podman socket
     shell: bash

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -29,9 +29,9 @@ runs:
       sudo apt-get install -y podman docker-compose
 
       # Workaround https://github.com/actions/runner-images/issues/7753
-      curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-1_amd64.deb
-      sudo dpkg -i containernetworking-plugins_1.1.1+ds1-1_amd64.deb
-      rm --force containernetworking-plugins_1.1.1+ds1-1_amd64.deb
+      curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+      sudo dpkg -i containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+      rm --force containernetworking-plugins_1.1.1+ds1-3_amd64.deb
 
       sudo systemctl enable --now podman.socket
 


### PR DESCRIPTION
Previous URL no longer exists:

http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/