### PR TITLE
packages: install epel-release from url since the package is not available in rhel

### DIFF
--- a/src/ansible/roles/packages/tasks/RedHat8.yml
+++ b/src/ansible/roles/packages/tasks/RedHat8.yml
@@ -5,8 +5,8 @@
 - name: Install EPEL repository
   dnf:
     state: present
-    name:
-    - epel-release
+    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm'
+    disable_gpg_check: yes
   when: extended_packageset
 
 - name: 'Packages are the same as in Fedora'


### PR DESCRIPTION
RHEL need epel-release specified with url as it is not part of normally available packages:
2023-10-06T10:51:00 TASK [packages : Install EPEL repository] **************************************
2023-10-06T10:51:01 fatal: [dns.test]: FAILED! => changed=false 
2023-10-06T10:51:01   failures:
2023-10-06T10:51:01   - No package epel-release available.
2023-10-06T10:51:01   msg: Failed to install some of the specified packages
2023-10-06T10:51:01   rc: 1
2023-10-06T10:51:01   results: []
...
With fix:
2023-10-06T12:49:39 TASK [packages : Install EPEL repository] **************************************
2023-10-06T12:49:41 changed: [dns.test]
2023-10-06T12:49:42 changed: [master.ldap.test]
2023-10-06T12:49:42 changed: [client.test]
2023-10-06T12:49:42 changed: [kdc.test]
2023-10-06T12:49:42 changed: [nfs.test]
2023-10-06T12:49:42 changed: [master.ipa.test]