### PR TITLE
build: disable nscd if present

### DIFF
--- a/src/ansible/playbook_image_service.yml
+++ b/src/ansible/playbook_image_service.yml
@@ -4,6 +4,7 @@
   roles:
   - facts
   - firewall
+  - no_nscd
 
 - hosts: master.ldap.test
   gather_facts: no

--- a/src/ansible/roles/no_nscd/tasks/main.yml
+++ b/src/ansible/roles/no_nscd/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Populate service facts
+  service_facts:
+
+- name: Disable nscd.service
+  service:
+    name: nscd.service
+    enabled: no
+    state: stopped
+  when: "ansible_facts.services['nscd.service'] is defined"
+
+- name: Disable nscd.socket
+  service:
+    name: nscd.socket
+    enabled: no
+    state: stopped
+  when: "ansible_facts.services['nscd.socket'] is defined"
+

--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -57,8 +57,10 @@
       - adcli
       - freeipa-client
       - nfs-common
+      - nslcd
       - packagekit
       - realmd
+      - slapd
       - sssd
       - sssd-*
   when: "'base_client' in group_names or 'client' in group_names"
@@ -178,7 +180,6 @@
       - libxml2-utils
       - lsb-release
       - make
-      - nslcd
       - packagekit
       - python3-dbus
       - python3-dev
@@ -189,7 +190,6 @@
       - python3-pytest
       - python3-requests
       - samba-dev
-      - slapd
       - softhsm2
       - uuid-dev
       - valgrind

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -47,8 +47,10 @@
       - adcli
       - freeipa-client
       - nfs-common
+      - nslcd
       - packagekit
       - realmd
+      - slapd
       - sssd
       - sssd-*
   - name: Install packages required for passkey testing
@@ -169,7 +171,6 @@
       - libxml2-utils
       - lsb-release
       - make
-      - nslcd
       - packagekit
       - pycodestyle
       - python3-dbus
@@ -181,7 +182,6 @@
       - python3-pytest
       - python3-requests
       - samba-dev
-      - slapd
       - softhsm2
       - uuid-dev
       - valgrind


### PR DESCRIPTION
On some platforms nscd might be pulled in and started via dependencies.
Since running SSSD together with nscd is not supported it should be
disabled if present.