### PR TITLE
adding backup dc to the root domain

### DIFF
--- a/src/Vagrantfile
+++ b/src/Vagrantfile
@@ -10,15 +10,36 @@ Vagrant.configure("2") do |config|
             :libvirt__dhcp_enabled => false,
             :libvirt__network_address => '172.16.200.0/24',
             :libvirt__forward_mode => 'route'
-
         this.vm.provider :libvirt do |libvirt|
             libvirt.memory = 4092
-
             if defined?(libvirt.qemu_use_session)
                 libvirt.qemu_use_session = false
             end
         end
+        this.vm.provision "ansible" do |ansible|
+            ansible.inventory_path = "./ansible/inventory.yml"
+            ansible.playbook = "./ansible/playbook_vagrant.yml"
+            ansible.config_file = "./ansible/ansible.cfg"
+        end
+    end
 
+    config.vm.define "ad1" do |this|
+        this.vm.box = "peru/windows-server-2022-standard-x64-eval"
+        this.vm.hostname = "dc1"
+        this.vm.guest = :windows
+        this.vm.communicator = "winrm"
+        this.winrm.username = "Administrator"
+        this.vm.network "private_network",
+            :ip => "172.16.200.11",
+            :libvirt__dhcp_enabled => false,
+            :libvirt__network_address => '172.16.200.0/24',
+            :libvirt__forward_mode => 'route'
+        this.vm.provider :libvirt do |libvirt|
+            libvirt.memory = 4092
+            if defined?(libvirt.qemu_use_session)
+                libvirt.qemu_use_session = false
+            end
+        end
         this.vm.provision "ansible" do |ansible|
             ansible.inventory_path = "./ansible/inventory.yml"
             ansible.playbook = "./ansible/playbook_vagrant.yml"

--- a/src/ansible/group_vars/all
+++ b/src/ansible/group_vars/all
@@ -43,6 +43,13 @@ service: {
     safe_password: Secret123,
     suffix: 'dc=ad,dc=test'
   }
+  ad1: {
+    domain: ad.test,
+    hostname: 'dc1',
+    netbios: AD1,
+    safe_password: Secret123,
+    suffix: 'dc=ad,dc=test'
+  }
 }
 
 user_regular_uid: 1000

--- a/src/ansible/inventory.yml
+++ b/src/ansible/inventory.yml
@@ -82,6 +82,8 @@ all:
           hosts:
             dc.ad.test:
               ansible_host: 172.16.200.10
+            dc1.ad.test:
+              ansible_host: 172.16.200.11
       vars:
         ansible_connection: winrm
         ansible_port: 5985

--- a/src/ansible/playbook_vagrant.yml
+++ b/src/ansible/playbook_vagrant.yml
@@ -3,3 +3,8 @@
   gather_facts: yes
   roles:
   - { role: ad, enable_firewall: yes }
+
+- hosts: dc1.ad.test
+  gather_facts: yes
+  roles:
+  - { role: ad, enable_firewall: yes, join_domain: yes }

--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -28,4 +28,4 @@
 - hosts: ad
   gather_facts: yes
   roles:
-  - { role: ad, skip_addc_install: yes, skip_dns: yes, ad_permanent_users: ['Administrator'] }
+    - { role: ad, skip_addc_install: yes, join_domain: no, skip_dns: yes, ad_permanent_users: ['Administrator'] }

--- a/src/ansible/roles/ad/defaults/main.yml
+++ b/src/ansible/roles/ad/defaults/main.yml
@@ -7,7 +7,11 @@ ad_permanent_users:
 skip_dns: no
 # Skip installation of AD server
 skip_addc_install: no
-# Skip addition of sudo shcmea and possibly other ones
+# Skip addition of sudo schema and possibly other ones
 skip_schema: no
-# Open firewall for all incomming traffic.
+# Open firewall for all incoming traffic.
 open_firewall: yes
+# Sets the primary addc
+primary_addc: yes
+# Joins the domain as an additional addc.
+join_domain: no

--- a/src/ansible/roles/ad/tasks/install.yml
+++ b/src/ansible/roles/ad/tasks/install.yml
@@ -26,7 +26,37 @@
   register: installation
   args:
     creates: 'C:\Windows\NTDS'
+  when: not join_domain
 
 - name: Reboot machine
   win_reboot:
   when: installation.changed
+
+- name: Join domain
+  win_domain_membership:
+    dns_domain_name: "{{ service.ad.domain }}"
+    domain_admin_user: "{{ ansible_user }}@{{ service.ad.domain }}"
+    domain_admin_password: "{{ service.ad.safe_password }}"
+    state: domain
+    register: join
+  when: join_domain
+
+- name: reboot windows server
+  win_reboot:
+  when: join.changed
+
+- name: 'Create new AD forest {{ service.ad.domain }}'
+  win_domain_controller:
+    dns_domain_name: "{{ service.ad.domain }}"
+    domain_admin_user: "{{ ansible_user }}@{{ meta_domain }}"
+    domain_admin_password: "{{ service.ad.safe_password }}" 
+    safe_mode_password: "{{ service.ad.safe_password }}"
+    install_dns: true
+    state: domain_controller
+  register: installation
+  when: join_domain
+
+- name: Reboot machine
+  win_reboot:
+  when: installation.reboot_required
+

--- a/src/tools/setup-dns-files.sh
+++ b/src/tools/setup-dns-files.sh
@@ -17,6 +17,7 @@ sed -i '/client.test/d' /etc/hosts
 sed -i '/nfs.test/d' /etc/hosts
 sed -i '/kdc.test/d' /etc/hosts
 sed -i '/dc.ad.test/d' /etc/hosts
+sed -i '/dc1.ad.test/d' /etc/hosts
 
 # Append the lines
 echo "172.16.100.10 master.ipa.test" >> /etc/hosts
@@ -26,3 +27,4 @@ echo "172.16.100.40 client.test" >> /etc/hosts
 echo "172.16.100.50 nfs.test" >> /etc/hosts
 echo "172.16.100.60 kdc.test" >> /etc/hosts
 echo "172.16.200.10 dc.ad.test" >> /etc/hosts
+echo "172.16.200.11 dc1.ad.test" >> /etc/hosts


### PR DESCRIPTION
Downstream tests will need a secondary domain controller for several test scenarios before they can be ported to the new framework.

- adding a new host to vagrant, ad1
- adding a new host to the inventory file
- creating new variable "join_domain" for when conditions
- updating dns files with host entry