### PR TITLE
ci: restart podman socket during setup

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -33,7 +33,8 @@ runs:
       sudo dpkg -i containernetworking-plugins_1.1.1+ds1-3_amd64.deb
       rm --force containernetworking-plugins_1.1.1+ds1-3_amd64.deb
 
-      sudo systemctl enable --now podman.socket
+      sudo systemctl enable podman.socket
+      sudo systemctl restart podman.socket
 
   - name: Checkout sssd-ci-containers repository
     uses: actions/checkout@v3


### PR DESCRIPTION
I'm not sure what is the exact root cause but this fixes an issue where `systemctl enable --now podman.socket` fails during container setup.

~~~
+ sudo systemctl enable --now podman.socket
Job failed. See "journalctl -xe" for details.

Nov 07 16:01:19 fv-az1153-970 sudo[3267]:   runner : *** ; USER=root ; COMMAND=/usr/bin/systemctl enable --now podman.socket
Nov 07 16:01:19 fv-az1153-970 systemd[1]: podman.socket: Socket service podman.service already active, refusing.
Nov 07 16:01:19 fv-az1153-970 systemd[1]: Failed to listen on Podman API Socket.
~~~

This leads to `docker-compose` failing as the service is [not started properly](https://github.com/docker/compose/issues/7896)
~~~
make: Entering directory '/home/runner/work/sssd/sssd/sssd-ci-containers'
docker-compose -f docker-compose.yml \
-f docker-compose.keycloak.yml \
-f docker-compose.passkey.yml down
The REGISTRY variable is not set. Defaulting to a blank string.
The TAG variable is not set. Defaulting to a blank string.
The HIDRAW variable is not set. Defaulting to a blank string.
[4439] Failed to execute script docker-compose
Traceback (most recent call last):
  File "urllib3/connectionpool.py", line 677, in urlopen
  File "urllib3/connectionpool.py", line 392, in _make_request
  File "http/client.py", line 1277, in request
  File "http/client.py", line 1323, in _send_request
  File "http/client.py", line 1272, in endheaders
  File "http/client.py", line 1032, in _send_output
  File "http/client.py", line 972, in send
  File "docker/transport/unixconn.py", line 43, in connect
ConnectionRefusedError: [Errno 111] Connection refused
~~~

I tested this with several CI runs in https://github.com/SSSD/sssd/pull/7019 which were successful.