### PR TITLE
ci: Allow overriding trust

### DIFF
--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -23,6 +23,8 @@
     join_ldap: "{{ override_join_ldap | default('yes') | bool }}"
     join_samba: "{{ override_join_samba | default('yes') | bool }}"
     join_ipa: "{{ override_join_ipa | default('yes') | bool }}"
+    trust_ipa_samba: "{{ override_trust_ipa_samba | default('yes') | bool }}"
+    trust_ipa_ad: "{{ override_trust_ipa_ad | default('yes') | bool }}"
     extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
 
 - hosts: ad


### PR DESCRIPTION
Allow overriding trust between IPA and samba and IPA and AD.