### PR TITLE
ci: Improve dynamic machine setup especially for randomized AD

### DIFF
--- a/src/ansible/group_vars/all
+++ b/src/ansible/group_vars/all
@@ -73,4 +73,5 @@ join_ldap: yes
 join_ad: no
 trust_ipa_samba: yes
 trust_ipa_ad: no
+trust_ipa_ad_two_way: no
 extended_packageset: yes

--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -1,7 +1,6 @@
 ---
-- hosts: dns
+- hosts: all
   gather_facts: yes
-  become: yes
   roles:
   - dns
 
@@ -25,6 +24,7 @@
     join_ipa: "{{ override_join_ipa | default('yes') | bool }}"
     trust_ipa_samba: "{{ override_trust_ipa_samba | default('yes') | bool }}"
     trust_ipa_ad: "{{ override_trust_ipa_ad | default('yes') | bool }}"
+    trust_ipa_ad_two_way: "{{ override_trust_ipa_ad_two_way | default('no') | bool }}"
     extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
 
 - hosts: ad

--- a/src/ansible/roles/ad/defaults/main.yml
+++ b/src/ansible/roles/ad/defaults/main.yml
@@ -7,7 +7,7 @@ ad_permanent_users:
 skip_dns: no
 # Skip installation of AD server
 skip_addc_install: no
-# Skip addition of sudo shcmea and possibly other ones
+# Skip addition of sudo schema and possibly other ones
 skip_schema: no
 # Open firewall for all incomming traffic.
 open_firewall: yes

--- a/src/ansible/roles/ad/tasks/dns.yml
+++ b/src/ansible/roles/ad/tasks/dns.yml
@@ -20,6 +20,6 @@
 
 - name: Remove vagrant IP address from DNS
   win_shell: |
-    Get-DnsServerResourceRecord -ZoneName "{{ service.ad.domain }}" -RRType A \
+    Get-DnsServerResourceRecord -ZoneName "{{ ad_domain }}" -RRType A \
       | Where-Object {$_.RecordData.ipv4address -ne "172.16.200.10"}          \
-      | Remove-DnsServerResourceRecord -ZoneName "{{ service.ad.domain }}" -Force
+      | Remove-DnsServerResourceRecord -ZoneName "{{ ad_domain }}" -Force

--- a/src/ansible/roles/ad/tasks/install.yml
+++ b/src/ansible/roles/ad/tasks/install.yml
@@ -8,21 +8,20 @@
   - AD-Domain-Services
   - DNS
 
-- name: 'Create new AD forest {{ service.ad.domain }}'
+- name: 'Create new AD forest {{ ad_domain }}'
   win_shell: |
     Import-Module ADDSDeployment
 
     Install-ADDSForest                                                        \
-      -DomainName "{{ service.ad.domain }}"                                   \
+      -DomainName "{{ ad_domain }}"                                           \
       -CreateDnsDelegation:$false                                             \
-      -DomainNetbiosName "{{ service.ad.netbios }}"                           \
       -ForestMode "WinThreshold"                                              \
       -DomainMode "WinThreshold"                                              \
       -Force:$true                                                            \
       -InstallDns:$true                                                       \
       -NoRebootOnCompletion:$true                                             \
       -SafeModeAdministratorPassword                                          \
-        (ConvertTo-SecureString '{{ service.ad.safe_password }}' -AsPlainText -Force)
+        (ConvertTo-SecureString '{{ ad_password }}' -AsPlainText -Force)
   register: installation
   args:
     creates: 'C:\Windows\NTDS'

--- a/src/ansible/roles/ad/tasks/main.yml
+++ b/src/ansible/roles/ad/tasks/main.yml
@@ -31,6 +31,17 @@
   win_reboot:
   when: configured_cygwin.changed and skip_addc_install
 
+- name: Prepare AD facts
+  set_fact:
+    ad_domain: "{{ '.'.join(inventory_hostname.split('.')[1:]) }}"
+    ad_netbios: "{{ inventory_hostname.split('.')[0].upper() }}"
+    ad_suffix: "{{ inventory_hostname.split('.')[1:] | map('regex_replace', '^(.*)$', 'dc=\\1') | join(',') }}"
+    ad_password: "{{ service.ad.safe_password }}"
+
+- name: Debug AD facts
+  debug:
+    msg: 'AD domain: "{{ ad_domain }}", AD netbios: "{{ ad_netbios }}", AD suffix: "{{ ad_suffix }}"'
+
 - name: 'Install AD server'
   include_tasks: 'install.yml'
   when: not skip_addc_install
@@ -56,13 +67,13 @@
   win_shell: |
     Import-Module ActiveDirectory
 
-    $user = Get-ADUser -Server {{ service.ad.domain }} -Identity {{ item }}   \
+    $user = Get-ADUser -Server {{ ad_domain }} -Identity {{ item }}   \
       -Properties PasswordNeverExpires
     if ($user.PasswordNeverExpires -eq $true) {
       exit 255
     }
 
-    Set-ADUser -Server {{ service.ad.domain }} -Identity {{ item }}           \
+    Set-ADUser -Server {{ ad_domain }} -Identity {{ item }}           \
       -PasswordNeverExpires $true
   register: result
   failed_when: "result.rc != 255 and result.rc != 0"

--- a/src/ansible/roles/ad/tasks/schema.yml
+++ b/src/ansible/roles/ad/tasks/schema.yml
@@ -7,7 +7,7 @@
 
 - name: Install additional schemas
   win_shell: |
-    ldifde -i -f C:\{{ item }}.schema -c dc=X {{ service.ad.suffix }} -b "Administrator" "{{ service.ad.domain }}" "{{ ansible_password }}"
+    ldifde -i -f C:\{{ item }}.schema -c dc=X {{ ad_suffix }} -b "Administrator" "{{ ad_domain }}" "{{ ansible_password }}"
   register: schema
   failed_when: schema.rc != 0 and schema.stdout is not search('ENTRY_EXISTS')
   changed_when: schema.rc == 0

--- a/src/ansible/roles/client/tasks/enroll_AD.yml
+++ b/src/ansible/roles/client/tasks/enroll_AD.yml
@@ -1,0 +1,47 @@
+---
+- name: Set AD facts
+  set_fact:
+    ad_domain: "{{ '.'.join(groups.ad.0.split('.')[1:]) }}"
+    safe_password: "{{ service.ad.safe_password }}"
+    ad_keytab: /enrollment/{{ '.'.join(groups.ad.0.split('.')[1:]) }}.keytab
+
+- name: Stat {{ ad_keytab }} to detect that we are already joined to AD
+  stat:
+    path:  "{{ ad_keytab }}"
+  register: enrollment_ad_1
+
+- name: Create /etc/krb5.conf for AD join
+  template:
+    src: krb5.conf
+    dest: /etc/krb5.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Join AD domain
+  command: realm join {{ ad_domain | quote }} --verbose
+  args:
+    stdin: '{{ safe_password }}'
+  when: not enrollment_ad_1.stat.exists
+
+- name: Stat {{ ad_keytab }}
+  stat:
+    path: "{{ ad_keytab }}"
+  register: enrollment_ad
+
+- name: Copy AD keytab to "{{ ad_keytab }}"
+  copy:
+    src: /etc/krb5.keytab
+    dest: "{{ ad_keytab }}"
+    mode: 0600
+    remote_src: yes
+  when: not enrollment_ad.stat.exists
+
+- name: Cleanup after joining the AD domain
+  file:
+    path: '{{ item }}'
+    state: absent
+  with_items:
+  - /etc/krb5.conf
+  - /etc/krb5.keytab
+  - /etc/sssd/sssd.conf

--- a/src/ansible/roles/client/tasks/enroll_IPA.yml
+++ b/src/ansible/roles/client/tasks/enroll_IPA.yml
@@ -1,0 +1,41 @@
+---
+- name: Set ipa facts
+  set_fact:
+    ipa_domain: "{{ hostvars[groups.ipa.0]['ipa_domain'] }}"
+    ipa_password: "{{ hostvars[groups.ipa.0].ansible_password | default(service.ipa.password) }}"
+    ipa_keytab: /enrollment/{{ hostvars[groups.ipa.0]['ipa_domain'] }}.keytab
+
+- name: Run ipa-client-install
+  shell: |
+    /usr/sbin/ipa-client-install --unattended --no-ntp \
+      --domain {{ ipa_domain | quote }}                \
+      --principal admin                                \
+      --password {{ ipa_password | quote }}
+  args:
+    creates: /etc/ipa/ca.crt
+
+- name: Stat {{ ipa_keytab }}
+  stat:
+    path: "{{ ipa_keytab }}"
+  register: enrollment_ipa
+
+- name: Copy IPA keytab to {{ ipa_keytab }}
+  copy:
+    src: /etc/krb5.keytab
+    dest: "{{ ipa_keytab }}"
+    mode: 0600
+    remote_src: yes
+  when: not enrollment_ipa.stat.exists
+
+- name: Cleanup after joining the IPA domain
+  file:
+    path: '{{ item }}'
+    state: absent
+  with_items:
+  - /etc/krb5.conf
+  - /etc/krb5.keytab
+  - /etc/sssd/sssd.conf
+
+- name: Add ipa to domains
+  set_fact:
+    domains: "{{ domains + [ipa_domain] }}"

--- a/src/ansible/roles/client/tasks/enroll_samba.yml
+++ b/src/ansible/roles/client/tasks/enroll_samba.yml
@@ -1,0 +1,51 @@
+---
+- name: Set Samba facts
+  set_fact:
+    samba_domain: "{{ hostvars[groups.samba.0]['samba_domain'] }}"
+    samba_password: "{{ hostvars[groups.samba.0].ansible_password | default(service.samba.password) }}"
+    samba_keytab: /enrollment/{{ hostvars[groups.samba.0]['samba_domain'] }}.keytab
+
+- name: Stat {{ samba_keytab }} to detect that we are already joined
+  stat:
+    path: "{{ samba_keytab }}"
+  register: enrollment_samba_1
+
+- name: Create /etc/krb5.conf for samba join
+  template:
+    src: krb5.conf
+    dest: /etc/krb5.conf
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Realm join Samba domain
+  command: realm join {{ samba_domain | quote }} --verbose
+  args:
+    stdin: '{{ samba_password }}'
+  when: not enrollment_samba_1.stat.exists
+
+- name: Stat {{ samba_keytab }}
+  stat:
+    path: "{{ samba_keytab }}"
+  register: enrollment_samba
+
+- name: Copy Samba keytab to {{ samba_keytab }}
+  copy:
+    src: /etc/krb5.keytab
+    dest: "{{ samba_keytab }}"
+    mode: 0600
+    remote_src: yes
+  when: not enrollment_samba.stat.exists
+
+- name: Cleanup after joining the Samba domain
+  file:
+    path: '{{ item }}'
+    state: absent
+  with_items:
+  - /etc/krb5.conf
+  - /etc/krb5.keytab
+  - /etc/sssd/sssd.conf
+
+- name: Add samba to domains
+  set_fact:
+    domains: "{{ domains + [samba_domain] }}"

--- a/src/ansible/roles/client/tasks/main.yml
+++ b/src/ansible/roles/client/tasks/main.yml
@@ -1,6 +1,7 @@
-- name: Set domains
+- name: Set facts for client
   set_fact:
     domains: []
+    client_fqdn: "{{ inventory_hostname }}"
 
 - name: Create /enrollment directory
   file:
@@ -11,141 +12,34 @@
     mode: '0700'
 
 - name: Join IPA domain
-  block:
-  - name: Run ipa-client-install
-    shell: |
-      /usr/sbin/ipa-client-install --unattended --no-ntp \
-        --domain {{ service.ipa.domain | quote }}        \
-        --principal admin                                \
-        --password {{ service.ipa.password | quote }}
-    args:
-      creates: /etc/ipa/ca.crt
-
-  - name: Stat /enrollment/ipa.keytab
-    stat:
-      path: /enrollment/ipa.keytab
-    register: enrollment_ipa
-
-  - name: Copy IPA keytab to /enrollment/ipa.keytab
-    copy:
-      src: /etc/krb5.keytab
-      dest: '/enrollment/ipa.keytab'
-      mode: 0600
-      remote_src: yes
-    when: not enrollment_ipa.stat.exists
-
-  - name: Cleanup after joining the IPA domain
-    file:
-      path: '{{ item }}'
-      state: absent
-    with_items:
-    - /etc/krb5.conf
-    - /etc/krb5.keytab
-    - /etc/sssd/sssd.conf
-
-  - name: Add ipa to domains
-    set_fact:
-      domains: "{{ domains + [service.ipa.domain] }}"
-  when: join_ipa
+  ansible.builtin.include_tasks:
+    file: enroll_IPA.yml
+  when:
+  - '"ipa" in groups and groups["ipa"]'
+  - join_ipa
 
 - name: Join Samba domain
-  block:
-  - name: Stat /enrollment/samba.keytab to detect that we are already joined
-    stat:
-      path:  /enrollment/samba.keytab
-    register: enrollment_samba_1
-
-  - name: Create /etc/krb5.conf for samba join
-    template:
-      src: krb5.conf
-      dest: /etc/krb5.conf
-      owner: root
-      group: root
-      mode: 0644
-
-  - name: Realm join Samba domain
-    command: realm join {{ service.samba.domain | quote }} --verbose
-    args:
-      stdin: '{{ service.samba.password }}'
-    when: not enrollment_samba_1.stat.exists
-
-  - name: Stat /enrollment/samba.keytab
-    stat:
-      path:  /enrollment/samba.keytab
-    register: enrollment_samba
-
-  - name: Copy Samba keytab to /enrollment/samba.keytab
-    copy:
-      src: /etc/krb5.keytab
-      dest: /enrollment/samba.keytab
-      mode: 0600
-      remote_src: yes
-    when: not enrollment_samba.stat.exists
-
-  - name: Cleanup after joining the Samba domain
-    file:
-      path: '{{ item }}'
-      state: absent
-    with_items:
-    - /etc/krb5.conf
-    - /etc/krb5.keytab
-    - /etc/sssd/sssd.conf
-
-  - name: Add samba to domains
-    set_fact:
-      domains: "{{ domains + [service.samba.domain] }}"
-  when: join_samba
+  ansible.builtin.include_tasks:
+    file: enroll_samba.yml
+  when:
+  - '"samba" in groups and groups["samba"]'
+  - join_samba
 
 - name: Join ldap domain
   block:
   - name: Add ldap to domains
     set_fact:
       domains: "{{ domains + [service.ldap.domain] }}"
-  when: join_ldap
+  when:
+  - '"ldap" in groups and groups["ldap"]'
+  - join_ldap
 
 - name: Join AD
-  block:
-  - name: Stat /enrollment/ad.keytab to detect that we are already joined
-    stat:
-      path:  /enrollment/ad.keytab
-    register: enrollment_ad_1
-
-  - name: Create /etc/krb5.conf for AD join
-    template:
-      src: krb5.conf
-      dest: /etc/krb5.conf
-      owner: root
-      group: root
-      mode: 0644
-
-  - name: Join AD domain
-    command: realm join {{ service.ad.domain | quote }} --verbose
-    args:
-      stdin: '{{ service.ad.safe_password }}'
-    when: not enrollment_ad_1.stat.exists
-
-  - name: Stat /enrollment/ad.keytab
-    stat:
-      path:  /enrollment/ad.keytab
-    register: enrollment_ad
-
-  - name: Copy AD keytab to /enrollment/ad.keytab
-    copy:
-      src: /etc/krb5.keytab
-      dest: /enrollment/ad.keytab
-      mode: 0600
-      remote_src: yes
-    when: not enrollment_ad.stat.exists
-
-  - name: Cleanup after joining the AD domain
-    file:
-      path: '{{ item }}'
-      state: absent
-    with_items:
-    - /etc/krb5.conf
-    - /etc/krb5.keytab
-    - /etc/sssd/sssd.conf
-  when: join_ad
+  ansible.builtin.include_tasks:
+    file: enroll_AD.yml
+  when:
+  - '"ad" in groups and groups["ad"]'
+  - join_ad
 
 - name: Stop SSSD
   service:

--- a/src/ansible/roles/client/templates/krb5.conf
+++ b/src/ansible/roles/client/templates/krb5.conf
@@ -8,7 +8,7 @@ rdns = false
 
 
 [realms]
-IPA.TEST = {
+{{ ipa_domain | upper }} = {
   pkinit_anchors = FILE:/var/lib/ipa-client/pki/kdc-ca-bundle.pem
   pkinit_pool = FILE:/var/lib/ipa-client/pki/ca-bundle.pem
 }

--- a/src/ansible/roles/client/templates/sssd.conf
+++ b/src/ansible/roles/client/templates/sssd.conf
@@ -15,25 +15,36 @@ use_fully_qualified_names = true
 {% endif %}
 
 {% if join_ipa %}
-[domain/{{ service.ipa.domain }}]
+[domain/{{ ipa_domain }}]
 id_provider = ipa
 access_provider = ipa
 ipa_server = _srv_
-ipa_domain = {{ service.ipa.domain }}
-ipa_hostname = {{ service.client.fqn }}
-krb5_keytab = /enrollment/ipa.keytab
-ldap_krb5_keytab = /enrollment/ipa.keytab
+ipa_domain = {{ ipa_domain }}
+ipa_hostname = {{ client_fqdn }}
+krb5_keytab = {{ ipa_keytab }}
+ldap_krb5_keytab =  {{ ipa_keytab }}
 use_fully_qualified_names = true
 {% endif %}
 
 {% if join_samba %}
-[domain/{{ service.samba.domain }}]
+[domain/{{ samba_domain }}]
 id_provider = ad
 access_provider = ad
 ad_server = _srv_
-ad_domain = {{ service.samba.domain }}
-ad_hostname = {{ service.client.fqn }}
-krb5_keytab = /enrollment/samba.keytab
-ldap_krb5_keytab = /enrollment/samba.keytab
+ad_domain = {{ samba_domain }}
+ad_hostname = {{ client_fqdn }}
+krb5_keytab = {{ samba_keytab }}
+ldap_krb5_keytab = {{ samba_keytab }}
+use_fully_qualified_names = true
+{% endif %}
+
+{% if join_ad %}
+[domain/{{ ad_domain }}]
+id_provider = ad
+access_provider = ad
+ad_server = _srv_
+ad_domain = {{ ad_domain }}
+ad_hostname = {{ client_fqdn }}
+krb5_keytab = {{ ad_keytab }}
 use_fully_qualified_names = true
 {% endif %}

--- a/src/ansible/roles/dns/tasks/main.yml
+++ b/src/ansible/roles/dns/tasks/main.yml
@@ -1,30 +1,41 @@
-- name: Install dnsmasq package
-  package:
-    name:
-    - dnsmasq
-    state: present
+- name: Gather facts
+  ansible.builtin.setup:
 
-- name: Place dnsmasq config
-  template:
-    src: etc.dnsmasq.conf.j2
-    dest: /etc/dnsmasq.conf
-    owner: root
-    group: root
-    mode: 0600
-  register: config
+- name: Setup dns (on dns machine)
+  block:
+  - name: Install dnsmasq package
+    ansible.builtin.package:
+      name:
+      - dnsmasq
+      state: present
 
-- name: Gather the package facts
-  package_facts:
+  - name: Place dnsmasq config
+    ansible.builtin.template:
+      src: etc.dnsmasq.conf.j2
+      dest: /etc/dnsmasq.conf
+      owner: root
+      group: root
+      mode: 0600
+    register: config
 
-- name: Disable systemd-resolved (if present)
-  service:
-    name: systemd-resolved
-    enabled: false
-    state: stopped
-  when: "'systemd-resolved' in ansible_facts.packages"
+  - name: Show dnsmasq templating results
+    ansible.builtin.debug:
+      msg: "{{ lookup('ansible.builtin.template', 'etc.dnsmasq.conf.j2') }}"
 
-- name: Restart dnsmasq service
-  service:
-    name: dnsmasq
-    enabled: true
-    state: restarted
+  - name: Gather the package facts
+    ansible.builtin.package_facts:
+
+  - name: Disable systemd-resolved (if present)
+    ansible.builtin.service:
+      name: systemd-resolved
+      enabled: false
+      state: stopped
+    when: "'systemd-resolved' in ansible_facts.packages"
+
+  - name: Restart dnsmasq service
+    ansible.builtin.service:
+      name: dnsmasq
+      enabled: true
+      state: restarted
+  when: "'dns' in group_names"
+  become: true

--- a/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
+++ b/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
@@ -1,10 +1,9 @@
 # This config is specific to downstream ci and does not
 # handle multiple AD DCs and other setups yet.
-# TODO: Add all AD servers
-# TODO: Remove meta_ip dependency (from  idm-ci).
-# TODO: Generalize this for all machines.
+# TODO: Add group DNS_SERVER that will contain all machines running dns to add them
+# as servers here like master.ipa.test dc.samba.test and ad.
 # dnsmasq config
-listen-address=::1,127.0.0.53,127.0.0.1,{{ hostvars['dns.test']['meta_ip'] }}
+listen-address=::1,127.0.0.53,127.0.0.1,{{ hostvars['dns.test']['ansible_facts']['default_ipv4']['address'] }}
 log-queries
 log-facility=-
 local=/test/
@@ -15,38 +14,17 @@ cache-size=0
 
 # These zones have their own DNS server
 {% if 'master.ipa.test' in hostvars %}
-server=/ipa.test/{{ hostvars['master.ipa.test']['meta_ip'] }}
+server=/ipa.test/{{ hostvars['master.ipa.test']['ansible_facts']['default_ipv4']['address'] }}
 {% endif %}
 {% if 'dc.samba.test' in hostvars %}
-server=/samba.test/{{ hostvars['dc.samba.test']['meta_ip'] }}
+server=/samba.test/{{ hostvars['dc.samba.test']['ansible_facts']['default_ipv4']['address'] }}
 {% endif %}
 {% if 'dc.ad.test' in hostvars %}
-server=/ad.test/{{ hostvars['dc.ad.test']['meta_ip'] }}
-{% endif %}
-
-
-#{% for host in vars['hostvars'] %}
-#address=/{{ host }}/{{ hostvars[host]['meta_ip'] }}
-#{% endfor %}
-
-
-# Add A records for LDAP, client and other machines without own DNS server
-{% if 'master.ldap.test' in hostvars %}
-address=/master.ldap.test/{{ hostvars['master.ldap.test']['meta_ip'] }}
-{% endif %}
-{% if 'client.test' in hostvars %}
-address=/client.test/{{ hostvars['client.test']['meta_ip'] }}
-{% endif %}
-{# For nfs and kdc we plan to put them alternatively on the ldap machine to save resources. #}
-{% if 'nfs.test' in hostvars %}
-address=/nfs.test/{{ hostvars['nfs.test']['meta_ip'] }}
-{% elif 'master.ldap.test' in hostvars %}
-address=/nfs.test/{{ hostvars['master.ldap.test']['meta_ip'] }}
-{% endif %}
-{% if 'kdc.test' in hostvars %}
-address=/kdc.test/{{ hostvars['kdc.test']['meta_ip'] }}
-{% elif 'master.ldap.test' in hostvars %}
-address=/kdc.test/{{ hostvars['master.ldap.test']['meta_ip'] }}
+server=/ad.test/{{ hostvars['dc.ad.test']['ansible_facts']['ip_addresses'][0] }}
+{% elif 'ad' in groups and groups['ad'] %}
+{% for ad in groups['ad'] %}
+server=/{{ hostvars[ad]['ansible_facts']['windows_domain'] }}/{{ hostvars[ad]['ansible_facts']['ip_addresses'][0] }}
+{% endfor %}
 {% endif %}
 
 # Add SRV record for LDAP
@@ -54,25 +32,20 @@ address=/kdc.test/{{ hostvars['master.ldap.test']['meta_ip'] }}
 srv-host=_ldap._tcp.ldap.test,master.ldap.test,389
 {% endif %}
 
-# Add PTR records for all machines
-{% if 'master.ipa.test' in hostvars %}
-ptr-record={{ hostvars['master.ipa.test']['meta_ip'].split('.') | reverse | join(".") }}.in-addr.arpa,master.ipa.test
+# All hosts A record
+{% for host in groups['all'] %}
+{% if hostvars[host].ansible_system == 'Linux' %}
+address=/{{ host }}/{{ hostvars[host]['ansible_facts']['default_ipv4']['address'] }}
+{% elif hostvars[host].ansible_system == 'Win32NT' %}
+address=/{{ host }}/{{ hostvars[host]['ansible_facts']['ip_addresses'][0] }}
 {% endif %}
-{% if 'master.ldap.test' in hostvars %}
-ptr-record={{ hostvars['master.ldap.test']['meta_ip'].split('.') | reverse | join(".") }}.in-addr.arpa,master.ldap.test
+{% endfor %}
+
+# All hosts PTR records
+{% for host in groups['all'] %}
+{% if hostvars[host].ansible_system == 'Linux' %}
+ptr-record={{ hostvars[host]['ansible_facts']['default_ipv4']['address'].split('.') | reverse | join(".") }}.in-addr.arpa,{{ host }}
+{% elif hostvars[host].ansible_system == 'Win32NT' %}
+ptr-record={{ hostvars[host]['ansible_facts']['ip_addresses'][0].split('.') | reverse | join(".") }}.in-addr.arpa,{{ host }}
 {% endif %}
-{% if 'dc.samba.test' in hostvars %}
-ptr-record={{ hostvars['dc.samba.test']['meta_ip'].split('.') | reverse | join(".") }}.in-addr.arpa,dc.samba.test
-{% endif %}
-{% if 'client.test' in hostvars %}
-ptr-record={{ hostvars['client.test']['meta_ip'].split('.') | reverse | join(".") }}.in-addr.arpa,client.test
-{% endif %}
-{% if 'dc.ad.test' in hostvars %}
-ptr-record={{ hostvars['dc.ad.test']['meta_ip'].split('.') | reverse | join(".") }}.in-addr.arpa,dc.ad.test
-{% endif %}
-{% if 'kdc.test' in hostvars %}
-ptr-record={{ hostvars['kdc.test']['meta_ip'].split('.') | reverse | join(".") }}.in-addr.arpa,kdc.test
-{% endif %}
-{% if 'nfs.test' in hostvars %}
-ptr-record={{ hostvars['nfs.test']['meta_ip'].split('.') | reverse | join(".") }}.in-addr.arpa,nfs.test
-{% endif %}
+{% endfor %}

--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -8,16 +8,27 @@
     ipa_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
   when: '"meta_ip" not in hostvars[inventory_hostname]'
 
+- name: Prepare IPA facts
+  set_fact:
+    ipa_domain: "{{ '.'.join(inventory_hostname.split('.')[1:]) }}"
+    ipa_netbios: "{{ inventory_hostname.split('.')[0].upper() }}"
+    ipa_suffix: "{{ inventory_hostname.split('.')[1:] | map('regex_replace', '^(.*)$', 'dc=\\1') | join(',') }}"
+    ipa_password: "{{ ansible_password | default(service.ipa.password)  }}"
+
+- name: Debug IPA facts
+  debug:
+    msg: 'IPA domain: "{{ ipa_domain }}", IPA netbios: "{{ ipa_netbios }}", IPA suffix: "{{ ipa_suffix }}"'
+
 - name: Install IPA server
   shell: |
     set -e
 
     alias install-ipa="/usr/sbin/ipa-server-install --unattended \
-      --realm={{ service.ipa.domain | upper | quote }}           \
-      --domain={{ service.ipa.domain | quote }}                  \
-      --netbios-name={{ service.ipa.netbios | quote }}           \
-      --ds-password={{ service.ipa.password | quote }}           \
-      --admin-password={{ service.ipa.password | quote }}        \
+      --realm={{ ipa_domain | upper | quote }}                   \
+      --domain={{ ipa_domain | quote }}                          \
+      --netbios-name={{ ipa_netbios| quote }}                    \
+      --ds-password={{ ipa_password | quote }}                   \
+      --admin-password={{ ipa_password | quote }}                \
       --setup-dns                                                \
       --ip-address={{ ipa_ip | quote }}                          \
       --setup-adtrust                                            \
@@ -49,7 +60,7 @@
     ipa automountmap-del default auto.master
     ipa automountmap-del default auto.direct
   args:
-    stdin: '{{ service.ipa.password }}'
+    stdin: '{{ ipa_password }}'
   register: automountmapdel
   failed_when:
   - 'automountmapdel.rc != 0 and "automount map not found" not in automountmapdel.stderr'
@@ -59,7 +70,7 @@
     kinit admin
     ipa group-add pw-never-expires
   args:
-    stdin: '{{ service.ipa.password }}'
+    stdin: '{{ ipa_password }}'
   register: pwneverexpires
   failed_when:
   - 'pwneverexpires.rc != 0 and "already exists" not in pwneverexpires.stderr'
@@ -69,7 +80,7 @@
     kinit admin
     ipa pwpolicy-add pw-never-expires --maxlife=0 --minlife=0 --priority=0
   args:
-    stdin: '{{ service.ipa.password }}'
+    stdin: '{{ ipa_password }}'
   register: policy
   failed_when:
   - 'policy.rc != 0 and "already used by pw-never-expires" not in policy.stderr'
@@ -79,7 +90,7 @@
     kinit admin
     ipa group-add-member pw-never-expires --users=admin
   args:
-    stdin: '{{ service.ipa.password }}'
+    stdin: '{{ ipa_password }}'
   register: member
   failed_when:
   - 'member.rc != 0 and "This entry is already a member" not in member.stdout'
@@ -90,8 +101,8 @@
     ipa user-mod admin --password
   args:
     stdin: |
-      {{ service.ipa.password }}
-      {{ service.ipa.password }}
+      {{ ipa_password }}
+      {{ ipa_password }}
 
 - name: 'Check trust with other domains'
   shell: |
@@ -99,32 +110,68 @@
     ipa trust-find
   args:
     stdin: |
-      {{ service.ipa.password }}
+      {{ ipa_password }}
   register: trust
   failed_when: False
 
-- name: 'Setup trust with {{ service.samba.domain }}'
-  shell: |
-    kinit admin
-    ipa trust-add {{ service.samba.domain | quote }} --admin Administrator --password
-  args:
-    stdin: |
-      {{ service.ipa.password }}
-      {{ service.samba.password }}
+- name: 'Setup trust with samba'
+  block:
+  - name: Set Samba facts (IPA)
+    set_fact:
+      samba_domain: "{{ '.'.join(hostvars[groups.samba.0].inventory_hostname.split('.')[1:]) }}"
+      samba_password: "{{ hostvars[groups.samba.0].ansible_password | default(service.ipa.password) }}"
+  - name: Debug Samba facts (IPA)
+    debug:
+      msg: 'Samba domain: "{{ samba_domain }}"'
+  - name: Run ipa trust-add
+    shell: |
+      kinit admin
+      ipa trust-add {{ samba_domain | quote }} --admin Administrator --password
+    args:
+      stdin: |
+        {{ ipa_password }}
+        {{ samba_password }}
+    when:
+    - 'samba_domain not in trust.stdout'
   when:
-  - 'service.samba.domain not in trust.stdout'
+  - '"samba" in groups and groups["samba"]'
   - join_samba
   - trust_ipa_samba
 
-- name: 'Setup trust with {{ service.ad.domain }}'
-  shell: |
-    kinit admin
-    ipa trust-add {{ service.ad.domain | quote }} --admin Administrator --password
-  args:
-    stdin: |
-      {{ service.ad.safe_password }}
-      {{ service.ad.safe_password }}
+- name: 'Setup trust with AD'
+  block:
+  - name: Set AD facts (IPA)
+    set_fact:
+      ad_domain: "{{ '.'.join(hostvars[groups.ad.0].inventory_hostname.split('.')[1:]) }}"
+      safe_password: "{{ service.ad.safe_password }}"
+      # TODO: range-type can be configurable ipa-ad-trust or ipa-ad-trust-posix
+      range_type: "--range-type=ipa-ad-trust"
+  - name: Debug AD facts (IPA)
+    debug:
+      msg: 'AD domain: "{{ ad_domain }}"'
+  - name: Run ipa trust-add
+    shell: |
+      kinit admin
+      ipa trust-add --type=ad {{ ad_domain | quote }} --admin Administrator --password {{ range_type }}
+    args:
+      stdin: |
+        {{ ipa_password }}
+        {{ safe_password }}
+    when:
+    - 'ad_domain not in trust.stdout'
+    - not trust_ipa_ad_two_way
+  - name: Run ipa trust-add (two-way)
+    shell: |
+      kinit admin
+      ipa trust-add --type=ad --two-way=true {{ ad_domain | quote }} --admin Administrator --password {{ range_type }}
+    args:
+      stdin: |
+        {{ ipa_password }}
+        {{ safe_password }}
+    when:
+    - 'ad_domain not in trust.stdout'
+    - trust_ipa_ad_two_way
   when:
-  - 'service.ad.domain not in trust.stdout'
+  - '"ad" in groups and groups["ad"]'
   - join_ad
   - trust_ipa_ad

--- a/src/ansible/roles/samba/tasks/main.yml
+++ b/src/ansible/roles/samba/tasks/main.yml
@@ -3,20 +3,86 @@
     path: /etc/samba/smb.conf
     state: absent
 
-- name: Disable systemd-resolved to clear DNS port
-  service:
-    name: systemd-resolved.service
-    enabled: no
-    state: stopped
+- name: Prepare Samba facts
+  set_fact:
+    samba_domain: "{{ '.'.join(inventory_hostname.split('.')[1:]) }}"
+    samba_netbios: "{{ inventory_hostname.split('.')[0].upper() }}"
+    samba_workgroup: "{{ inventory_hostname.split('.')[1].upper() }}"
+    samba_suffix: "{{ inventory_hostname.split('.')[1:] | map('regex_replace', '^(.*)$', 'dc=\\1') | join(',') }}"
+    samba_password: "{{ hostvars[inventory_hostname].ansible_password | default(service.samba.password) }}"
+
+- name: Debug Samba facts
+  debug:
+    msg: |
+      Samba domain: "{{ samba_domain }}"
+      Samba workgroup: "{{ samba_workgroup }}"
+      Samba suffix: "{{ samba_suffix }}"
+      Samba netbios: "{{ samba_netbios }}"
+
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+
+- name: Get rid of systemd-resolved
+  block:
+  - name: List mounts
+    ansible.builtin.command: mount
+    register: mounts
+  - name: Disable systemd-resolved to clear DNS port
+    ansible.builtin.service:
+      name: systemd-resolved.service
+      enabled: no
+      state: stopped
+  # In VMs we want to use network manager resolv conf instead
+  # of systemd-resolved stub.
+  - name: Replace /etc/resolv.conf with network manager
+    ansible.builtin.file:
+      src: /run/NetworkManager/resolv.conf
+      dest: /etc/resolv.conf
+      state: link
+      force: yes
+      owner: root
+      group: root
+      mode: '0660'
+    when: '"resolv.conf" not in mounts.stdout'
+  - name: Create NetworkManager dns override
+    ansible.builtin.copy:
+      content: |
+        [main]
+        dns=none
+      dest: /etc/NetworkManager/conf.d/90-dns-none.conf
+    register: NetworkManager_configured
+    when: '"resolv.conf" not in mounts.stdout'
+  - name: Restart NetworkManager
+    ansible.builtin.service:
+      name: NetworkManager
+      state: restarted
+    when:
+    - '"resolv.conf" not in mounts.stdout'
+    - NetworkManager_configured.changed
+  # In containers the file is a mounted from outside so
+  # we change the content.
+  - name: Change resolv.conf
+    lineinfile:
+      path: /etc/resolv.conf
+      insertbefore: BOF
+      line: "nameserver {{ hostvars[groups.dns.0]['ansible_facts']['default_ipv4']['address'] }}"
+    when:
+    - '"resolv.conf" in mounts.stdout'
+    - '"dns" in groups and groups["dns"]'
+  - name: Remove systemd-resolved package
+    ansible.builtin.package:
+      name: systemd-resolved
+      state: absent
+  when: "'systemd-resolved' in ansible_facts.packages"
 
 - name: Install Samba domain
   shell: |
-    /usr/bin/samba-tool domain provision                        \
-      --realm={{ service.samba.domain | upper | quote }}        \
-      --domain={{ service.samba.netbios | quote }}              \
-      --adminpass={{ service.samba.password | quote }}          \
-      --krbtgtpass={{ service.samba.password | quote }}         \
-      --dnspass={{ service.samba.password | quote }}            \
+    /usr/bin/samba-tool domain provision               \
+      --realm={{ samba_domain | upper | quote }}       \
+      --domain={{ samba_workgroup | quote }}           \
+      --adminpass={{ samba_password | quote }}          \
+      --krbtgtpass={{ samba_password | quote }}         \
+      --dnspass={{ samba_password | quote }}            \
       --use-rfc2307
   args:
     creates: /etc/samba/smb.conf
@@ -29,6 +95,8 @@
     force: yes
     remote_src: yes
 
+# TODO: The hardcoded certs should be replaced
+# by ones based on real based on hostnames
 - name: Replace TLS certificates
   ini_file:
     path: /etc/samba/smb.conf
@@ -59,9 +127,12 @@
     backup: no
 
 - name: Copy sudo schema
-  copy:
-    src: '{{ item }}'
+  template:
+    src: '{{ item }}.j2'
     dest: '/etc/samba/{{ item }}'
+    owner: root
+    group: root
+    mode: 0644
   with_items:
   - sudo.attrs.ldif
   - sudo.class.ldif

--- a/src/ansible/roles/samba/templates/sudo.attrs.ldif.j2
+++ b/src/ansible/roles/samba/templates/sudo.attrs.ldif.j2
@@ -1,4 +1,4 @@
-dn: CN=sudoUser,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoUser,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.1
@@ -11,7 +11,7 @@ attributeSyntax: 2.5.5.5
 oMSyntax: 22
 isSingleValued: FALSE
 
-dn: CN=sudoHost,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoHost,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.2
@@ -24,7 +24,7 @@ attributeSyntax: 2.5.5.5
 oMSyntax: 22
 isSingleValued: FALSE
 
-dn: CN=sudoCommand,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoCommand,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.3
@@ -37,7 +37,7 @@ attributeSyntax: 2.5.5.5
 oMSyntax: 22
 isSingleValued: FALSE
 
-dn: CN=sudoRunAs,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoRunAs,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.4
@@ -50,7 +50,7 @@ attributeSyntax: 2.5.5.5
 oMSyntax: 22
 isSingleValued: FALSE
 
-dn: CN=sudoOption,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoOption,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.5
@@ -63,7 +63,7 @@ attributeSyntax: 2.5.5.5
 oMSyntax: 22
 isSingleValued: FALSE
 
-dn: CN=sudoRunAsUser,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoRunAsUser,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.6
@@ -76,7 +76,7 @@ attributeSyntax: 2.5.5.5
 oMSyntax: 22
 isSingleValued: FALSE
 
-dn: CN=sudoRunAsGroup,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoRunAsGroup,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.7
@@ -89,7 +89,7 @@ attributeSyntax: 2.5.5.5
 oMSyntax: 22
 isSingleValued: FALSE
 
-dn: CN=sudoNotBefore,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoNotBefore,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.8
@@ -102,7 +102,7 @@ attributeSyntax: 2.5.5.11
 oMSyntax: 24
 isSingleValued: FALSE
 
-dn: CN=sudoNotAfter,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoNotAfter,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.9
@@ -115,7 +115,7 @@ attributeSyntax: 2.5.5.11
 oMSyntax: 24
 isSingleValued: FALSE
 
-dn: CN=sudoOrder,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoOrder,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: attributeSchema
 attributeID: 1.3.6.1.4.1.15953.9.1.10

--- a/src/ansible/roles/samba/templates/sudo.class.ldif.j2
+++ b/src/ansible/roles/samba/templates/sudo.class.ldif.j2
@@ -1,4 +1,4 @@
-dn: CN=sudoRole,CN=Schema,CN=Configuration,dc=samba,dc=test
+dn: CN=sudoRole,CN=Schema,CN=Configuration,{{ samba_suffix }}
 objectClass: top
 objectClass: classSchema
 governsID: 1.3.6.1.4.1.15953.9.2.1
@@ -22,5 +22,5 @@ mayContain: sudoNotBefore
 mayContain: sudoNotAfter
 mayContain: description
 possSuperiors: top
-defaultObjectCategory: CN=sudoRole,CN=Schema,CN=Configuration,dc=samba,dc=test
+defaultObjectCategory: CN=sudoRole,CN=Schema,CN=Configuration,{{ samba_suffix }}
 defaultSecurityDescriptor: D:(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;SY)(A;;RPWPCRCCDCLCLORCWOWDSDDTSW;;;DA)(OA;;CCDC;bf967a86-0de6-11d0-a285-00aa003049e2;;AO)(OA;;CCDC;bf967aba-0de6-11d0-a285-00aa003049e2;;AO)(OA;;CCDC;bf967a9c-0de6-11d0-a285-00aa003049e2;;AO)(OA;;CCDC;bf967aa8-0de6-11d0-a285-00aa003049e2;;PO)(A;;RPLCLORC;;;AU)(A;;LCRPLORC;;;ED)(OA;;CCDC;4828CC14-1437-45bc-9B07-AD6F015E5F28;;AO)


### PR DESCRIPTION
Improve dns role to be less reliant on idmci and work with machines more dynamically.
Update ipa and client roles to handle better missing backends.
Change ad role to allow hostname/domain randomization. 
Remove partially service.XXX style config in a favour of dynamic configuration. 
Refactor joining domains (IPA, AD samba) to standalone files.