### PR TITLE
Fedora: remove 'nodocs' from dnf.conf::tsflags

### DIFF
--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -1,3 +1,17 @@
+- name: Enable docs installation by default
+  block:
+  - name: Check dnf.conf exists
+    stat:
+      path: /etc/dnf/dnf.conf
+    register: dnf_stat_result
+
+  - name: Patch dnf.conf
+    replace:
+      path: /etc/dnf/dnf.conf
+      regexp: 'nodocs'
+      replace: ''
+    when: dnf_stat_result.stat.exists
+
 - name: Select packageset
   set_fact:
     extended_packageset: "{{ extended_packageset | default('no') }}"


### PR DESCRIPTION
To allow man pages installation. This is to enable proper feature detection that rely on man pages content.