### PR TITLE
build: build base images in unconfined mode

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -18,4 +18,5 @@ runs:
   - name: Enable podman socket
     shell: bash
     run: |
-      sudo systemctl enable --now podman.socket
+      sudo systemctl enable podman.socket
+      sudo systemctl restart podman.socket

--- a/src/build.sh
+++ b/src/build.sh
@@ -92,7 +92,7 @@ function build_base_image {
   done
 
   echo "Building $name from $from"
-  ${DOCKER} run --name sssd-wip-base --detach -i "$from"
+  ${DOCKER} run --security-opt seccomp=unconfined --name sssd-wip-base --detach -i "$from"
   if [ $name == 'base-ground' ]; then
     base_install_python
   fi


### PR DESCRIPTION
To workaround [1] in Github actions environment. Github Actions Runners
do not yet have up to date podman version that contains this fix.

[1] https://github.com/containers/podman/issues/21012