### PR TITLE
ipa: manage reverse zone for artificial hosts

### DIFF
--- a/data/configs/dnsmasq.conf
+++ b/data/configs/dnsmasq.conf
@@ -15,6 +15,9 @@ server=/ipa.test/172.16.100.10
 server=/samba.test/172.16.100.30
 server=/ad.test/172.16.200.10
 
+# Add reverse zones for artificial hosts in IPA domain
+server=/251.255.10.in-addr.arpa/172.16.100.10
+
 # Add A records for LDAP, client and other machines without own DNS server
 address=/master.ldap.test/172.16.100.20
 address=/client.test/172.16.100.40

--- a/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
+++ b/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
@@ -27,6 +27,9 @@ server=/{{ hostvars[ad]['ansible_facts']['windows_domain'] }}/{{ hostvars[ad]['a
 {% endfor %}
 {% endif %}
 
+# Add reverse zones for artificial hosts in IPA domain
+server=/251.255.10.in-addr.arpa/{{ hostvars['master.ipa.test']['ansible_facts']['default_ipv4']['address'] }}
+
 # Add SRV record for LDAP
 {% if 'master.ldap.test' in hostvars %}
 srv-host=_ldap._tcp.ldap.test,master.ldap.test,389

--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -104,6 +104,13 @@
       {{ ipa_password }}
       {{ ipa_password }}
 
+- name: Add reverse zone for artificial hosts
+  shell: |
+    kinit admin
+    ipa --no-prompt dnszone-add --name-from-ip 10.255.251.0/24
+  args:
+    stdin: '{{ ipa_password }}'
+
 - name: 'Check trust with other domains'
   shell: |
     kinit admin


### PR DESCRIPTION
In order to test sss_ssh_knownhosts command, we need to have
a valid reverse zone so we can add a host with known certificate
that can be resolved though hostname and reverse lookup of IP address.