### PR TITLE
Samba: reduce default log level

### DIFF
--- a/src/ansible/roles/samba/tasks/main.yml
+++ b/src/ansible/roles/samba/tasks/main.yml
@@ -131,7 +131,7 @@
     path: /etc/samba/smb.conf
     section: global
     option: "log level"
-    value: 10
+    value: "1 auth:7 rpc_srv:7 sam:7 winbind:7"
     mode: '0600'
     backup: no
 


### PR DESCRIPTION
7 should be enough for daemons, and command line tools don't need high verbosity at all (otherwise mh.log gets spammed)