### PR TITLE
provision: Make cleanup skipped again on VMs.

### DIFF
--- a/src/ansible/playbook_image_service.yml
+++ b/src/ansible/playbook_image_service.yml
@@ -47,4 +47,9 @@
   gather_facts: no
   roles:
   - ssh_server
-  - cleanup
+
+- hosts: services
+  gather_facts: no
+  roles:
+  - role: cleanup
+    when: skip_cleanup is undefined or not skip_cleanup

--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -26,6 +26,7 @@
     trust_ipa_ad: "{{ override_trust_ipa_ad | default('yes') | bool }}"
     trust_ipa_ad_two_way: "{{ override_trust_ipa_ad_two_way | default('no') | bool }}"
     extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
+    skip_cleanup: true
 
 - hosts: ad
   gather_facts: yes


### PR DESCRIPTION
There is no point in switching off ldap and ipa on VMs.