### PR TITLE
Install sssd-ldap package on IPA container

### DIFF
--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -72,6 +72,13 @@
       - augeas-tools
   when: "'base_client' in group_names or 'client' in group_names"
 
+  - name: Install test dependencies on IPA server
+    apt:
+      state: present
+      name:
+      - sssd-ldap*
+  when: "'base_ipa' in group_names or 'ipa' in group_names"
+
 - name: Install packages for NFS base image
   block:
   - name: Install NFS

--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -70,14 +70,8 @@
       update_cache: yes
       name:
       - augeas-tools
+      - 389-ds-base
   when: "'base_client' in group_names or 'client' in group_names"
-
-  - name: Install test dependencies on IPA server
-    apt:
-      state: present
-      name:
-      - sssd-ldap*
-  when: "'base_ipa' in group_names or 'ipa' in group_names"
 
 - name: Install packages for NFS base image
   block:

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -193,7 +193,9 @@
   - name: Install IPA
     dnf:
       state: present
-      name: '{{ ipa.server }}'
+      name: 
+      - '{{ ipa.server }}'
+      - sssd-ldap*
   when: "'base_ipa' in group_names or 'ipa' in group_names"
 
 - name: Install packages for Samba base image

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -176,6 +176,11 @@
         - vpcd
       disable_gpg_check: yes
     when: virt_smartcard
+  - name: Install 389ds
+    dnf:
+      state: present
+      name:
+      - 389-ds-base
   when: "'base_client' in group_names or 'client' in group_names"
 
 - name: Install packages for LDAP base image
@@ -195,7 +200,6 @@
       state: present
       name: 
       - '{{ ipa.server }}'
-      - sssd-ldap*
   when: "'base_ipa' in group_names or 'ipa' in group_names"
 
 - name: Install packages for Samba base image

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -60,6 +60,12 @@
       update_cache: yes
       name:
       - augeas-tools
+  - name: Install test dependencies on IPA server
+    apt:
+      state: present
+      name:
+      - sssd-ldap*
+  when: "'base_ipa' in group_names or 'ipa' in group_names"
   - name: Install packages required for passkey testing
     apt:
       state: present

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -60,12 +60,7 @@
       update_cache: yes
       name:
       - augeas-tools
-  - name: Install test dependencies on IPA server
-    apt:
-      state: present
-      name:
-      - sssd-ldap*
-  when: "'base_ipa' in group_names or 'ipa' in group_names"
+      - 389-ds-base
   - name: Install packages required for passkey testing
     apt:
       state: present


### PR DESCRIPTION
This PR is to resolve the issue encountered during the conversion of test_ldapapi to the new test framework.

In this feature, IPA, which stands for Identity Policy and Audit, serves as the upstream name. 389 operates as the backend, functioning as an LDAP server. To establish a connection to the LDAP database over a UNIX socket, it is necessary to install the sssd.ldap package on the IPA host.