### PR TITLE
provision: do not join domains automatically in Idm CI

### DIFF
--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -19,12 +19,12 @@
     passkey_support: "{{ override_passkey_support | default('no') | bool }}"
     user_regular_uid: 1024
     ansible_become: yes
-    join_ad: "{{ override_join_ad | default('yes') | bool }}"
-    join_ldap: "{{ override_join_ldap | default('yes') | bool }}"
-    join_samba: "{{ override_join_samba | default('yes') | bool }}"
-    join_ipa: "{{ override_join_ipa | default('yes') | bool }}"
-    trust_ipa_samba: "{{ override_trust_ipa_samba | default('yes') | bool }}"
-    trust_ipa_ad: "{{ override_trust_ipa_ad | default('yes') | bool }}"
+    join_ad: "{{ override_join_ad | default('no') | bool }}"
+    join_ldap: "{{ override_join_ldap | default('no') | bool }}"
+    join_samba: "{{ override_join_samba | default('no') | bool }}"
+    join_ipa: "{{ override_join_ipa | default('no') | bool }}"
+    trust_ipa_samba: "{{ override_trust_ipa_samba | default('no') | bool }}"
+    trust_ipa_ad: "{{ override_trust_ipa_ad | default('no') | bool }}"
     trust_ipa_ad_two_way: "{{ override_trust_ipa_ad_two_way | default('no') | bool }}"
     extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
     skip_cleanup: true

--- a/src/ansible/roles/client/templates/krb5.conf
+++ b/src/ansible/roles/client/templates/krb5.conf
@@ -6,9 +6,10 @@ ticket_lifetime = 24h
 forwardable = true
 rdns = false
 
-
+{% if join_ipa %}
 [realms]
 {{ ipa_domain | upper }} = {
   pkinit_anchors = FILE:/var/lib/ipa-client/pki/kdc-ca-bundle.pem
   pkinit_pool = FILE:/var/lib/ipa-client/pki/ca-bundle.pem
 }
+{% endif %}

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -194,6 +194,11 @@
     dnf:
       state: present
       name: '{{ ipa.server }}'
+
+  - name: Install sssd-kcm
+    dnf:
+      state: present
+      name: sssd-kcm
   when: "'base_ipa' in group_names or 'ipa' in group_names"
 
 - name: Install packages for Samba base image

--- a/src/ansible/roles/samba/tasks/main.yml
+++ b/src/ansible/roles/samba/tasks/main.yml
@@ -135,6 +135,15 @@
     mode: '0600'
     backup: no
 
+- name: Set idmap range
+  ini_file:
+    path: /etc/samba/smb.conf
+    section: global
+    option: "idmap config * : range"
+    value: "1000000-1999999"
+    mode: '0600'
+    backup: no
+
 - name: Copy sudo schema
   template:
     src: '{{ item }}.j2'


### PR DESCRIPTION
    Currently, we provide machines that are already fully setup with the
    client enrolled into all domains and trusts established. This is no
    longer necessary. With this patch, we will enroll into the domains
    using per-topology setup if needed.

    This applies only to downstream CI. Containers are still fully provisioned.

Please note that this needs to be closed together with changes to other repositories:
* https://github.com/SSSD/sssd/pull/7349
* https://github.com/next-actions/pytest-mh/pull/54
* https://github.com/next-actions/pytest-mh/pull/54