### PR TITLE
Remove http-parser dependency

### DIFF
--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -149,7 +149,6 @@
       - libdbus-1-dev
       - libdhash-dev
       - libglib2.0-dev
-      - libhttp-parser-dev
       - libini-config-dev
       - libjansson-dev
       - libkeyutils-dev

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -270,7 +270,6 @@
       - curl-devel
       - dbus-daemon
       - fakeroot
-      - http-parser-devel
       - krb5-server
       - krb5-workstation
       - libcmocka-devel

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -141,7 +141,6 @@
       - libdbus-1-dev
       - libdhash-dev
       - libglib2.0-dev
-      - libhttp-parser-dev
       - libini-config-dev
       - libjansson-dev
       - libkeyutils-dev


### PR DESCRIPTION
It's not used to build SSSD since
https://github.com/SSSD/sssd/commit/10069b1d39e671b7502c5211883c94ceaa91aebb