### PR TITLE
build: use dnf5 when available

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -68,9 +68,9 @@ function base_install_python {
     fi
   fi
 
-  # Remove dnf-5 to workaround many issues that yet needs to be fixed
+  # Install dnf5 python module
   if base_exec '[ -f /usr/bin/dnf5 ]'; then
-    base_exec 'dnf install -y python3-dnf && dnf remove -y dnf5 && ln -s /usr/bin/dnf-3 /usr/bin/dnf && ln -s /usr/bin/dnf-3 /usr/bin/yum && dnf clean all'
+    base_exec 'dnf install -y python3-libdnf5 && dnf clean all'
   fi
 }
 


### PR DESCRIPTION
dnf5 is now a protected package in rawhide and cannot be removed.
We need to start using it.