### PR TITLE
ci: Switch c8s repos to vault

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,12 +1,30 @@
 name: 'Install dependencies'
 description: 'Install dependencies for building and publishing containers'
+
+inputs:
+  tag:
+    description: Built container tag.
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
-  - name: Install packages
+  - name: Install python packages with older ansible for Centos 8
+    if: ${{ inputs.tag == 'centos-8' }}
+    shell: bash
+    run: |
+      sudo pip3 install ansible==9.8 passlib
+
+  - name: Install python packages
+    if: ${{ inputs.tag != 'centos-8' }}
     shell: bash
     run: |
       sudo pip3 install ansible passlib
+
+  - name: Install deb packages
+    shell: bash
+    run: |
       sudo apt-get update
       sudo apt-get install -y podman docker-compose
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
+      with:
+        tag: ${{ matrix.image.tag }}
 
     - name: Build images
       uses: ./.github/actions/build
@@ -89,6 +91,8 @@ jobs:
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
+      with:
+        tag: ${{ matrix.image.tag }}
 
     - name: Build images
       uses: ./.github/actions/build

--- a/src/ansible/roles/packages/tasks/CentOS8.yml
+++ b/src/ansible/roles/packages/tasks/CentOS8.yml
@@ -6,7 +6,7 @@
       name:
       - dnf-plugins-core
 
-  - name: Install buildroot
+  - name: Install additional repos
     template:
       src: repo
       dest: '/etc/yum.repos.d/{{ item.name }}.repo'
@@ -15,6 +15,7 @@
       mode: 0644
     with_items:
     - {name: 'buildroot', url: 'https://kojihub.stream.centos.org/kojifiles/repos/c8s-build/latest/$basearch'}
+    - {name: 'crb', url: 'http://vault.centos.org/centos/8-stream/PowerTools/$basearch/os/'}
     when: buildroot
 
   - name: Install EPEL repository

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -186,6 +186,7 @@
         - softhsm
         - nss-tools
         - selinux-policy-devel
+        - selinux-policy-targeted
         - make
     when: virt_smartcard
 

--- a/src/ansible/roles/packages/templates/repo
+++ b/src/ansible/roles/packages/templates/repo
@@ -3,3 +3,4 @@ name={{ item.name }}
 baseurl={{ item.url }}
 enabled=1
 gpgcheck=0
+skip_if_unavailable=True

--- a/src/build.sh
+++ b/src/build.sh
@@ -57,6 +57,12 @@ function base_exec {
   ${DOCKER} exec sssd-wip-base /bin/bash -c "$1"
 }
 
+function c8s_repo {
+    # Update repos to working ones
+    ${DOCKER} exec sssd-wip-base /bin/bash -c 'grep -q "CentOS Stream 8" /etc/os-release && sed -i "s/mirrorlist/#mirrorlist/g" /etc/yum.repos.d/CentOS-* || true'
+    ${DOCKER} exec sssd-wip-base /bin/bash -c 'grep -q "CentOS Stream 8" /etc/os-release && sed -i "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* || true'
+}
+
 # Make sure that Ansible dependencies are installed so we can run playbooks
 function base_install_python {
   # Install python3 if not available
@@ -94,9 +100,9 @@ function build_base_image {
   echo "Building $name from $from"
   ${DOCKER} run --security-opt seccomp=unconfined --name sssd-wip-base --detach -i "$from"
   if [ $name == 'base-ground' ]; then
+    c8s_repo
     base_install_python
   fi
-
   ansible-playbook --limit "`echo $name | sed -r 's/-/_/g'`" ./ansible/playbook_image_base.yml
   ${DOCKER} stop sssd-wip-base
   ${DOCKER} commit                     \


### PR DESCRIPTION
- The original centos mirrors no longer work so we need to switch to vault repos instead.
- ansible-core-2.17 is not compatible with CentOS 8 so we need to use older 2.16 version.
- C8s Buildroot is not available atm. in koji so we in non-mandatory repo.
- Crb (powertools) repo is needed for some packages from client-devel
- We need to make sure seliinux-poilicy-targeted needed by smartcards is installed on c8s.