### PR TITLE
dns: Tweak dns role to work better with systemd-resolved

### DIFF
--- a/src/ansible/roles/dns/tasks/main.yml
+++ b/src/ansible/roles/dns/tasks/main.yml
@@ -1,6 +1,14 @@
 - name: Gather facts
   ansible.builtin.setup:
 
+- name: Add fqdn and short hostname to /etc/hosts
+  ansible.builtin.lineinfile:
+    line: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }} \
+      {{ inventory_hostname }} {{ inventory_hostname.split('.')[0] }}"
+    path: /etc/hosts
+  when: ansible_os_family != "Windows"
+  become: true
+
 - name: Setup dns (on dns machine)
   block:
   - name: Install dnsmasq package
@@ -25,17 +33,41 @@
   - name: Gather the package facts
     ansible.builtin.package_facts:
 
-  - name: Disable systemd-resolved (if present)
-    ansible.builtin.service:
+  - name: Create dnsmasq.service.d if needed
+    ansible.builtin.file:
+      path: /etc/systemd/system/dnsmasq.service.d/
+      state: directory
+      recurse: yes
+      owner: root
+      group: root
+
+  - name: Force dnsmasq before systemd-resolved
+    copy:
+      content: |
+        [Unit]
+        After=systemd-resolved.service
+        [Service]
+        ExecStartPre=/usr/bin/systemctl stop systemd-resolved.service
+        ExecStartPost=/usr/bin/systemctl start systemd-resolved.service
+      dest: /etc/systemd/system/dnsmasq.service.d/resolved-fix.conf
+      owner: root
+      group: root
+      mode: '0644'
+    when: "'systemd-resolved' in ansible_facts.packages"
+
+  - name: Restart systemd-resolved (if present)
+    ansible.builtin.systemd_service:
       name: systemd-resolved
-      enabled: false
-      state: stopped
+      daemon_reload: true
+      state: restarted
     when: "'systemd-resolved' in ansible_facts.packages"
 
   - name: Restart dnsmasq service
-    ansible.builtin.service:
+    ansible.builtin.systemd_service:
       name: dnsmasq
       enabled: true
+      daemon_reload: true
       state: restarted
+
   when: "'dns' in group_names"
   become: true

--- a/src/ansible/roles/samba/tasks/main.yml
+++ b/src/ansible/roles/samba/tasks/main.yml
@@ -62,12 +62,13 @@
   # In containers the file is a mounted from outside so
   # we change the content.
   - name: Change resolv.conf
-    lineinfile:
+    blockinfile:
       path: /etc/resolv.conf
       insertbefore: BOF
-      line: "nameserver {{ hostvars[groups.dns.0]['ansible_facts']['default_ipv4']['address'] }}"
+      block: |
+        nameserver 127.0.0.1
+        nameserver {{ hostvars[groups.dns.0]['ansible_facts']['default_ipv4']['address'] }}
     when:
-    - '"resolv.conf" in mounts.stdout'
     - '"dns" in groups and groups["dns"]'
   - name: Remove systemd-resolved package
     ansible.builtin.package:
@@ -86,6 +87,17 @@
       --use-rfc2307
   args:
     creates: /etc/samba/smb.conf
+
+- name: Set forwarder to dns server
+  ini_file:
+    path: /etc/samba/smb.conf
+    section: global
+    option: "dns forwarder"
+    value: "{{ hostvars[groups.dns.0]['ansible_facts']['default_ipv4']['address'] }}"
+    mode: '0600'
+    backup: no
+  when:
+  - '"dns" in groups and groups["dns"]'
 
 - name: Setup Kerberos
   copy:


### PR DESCRIPTION
This fixes dns installation on dns machine and samba installation on fedora 40 in idmci by removing systemd-resolved pieces in the correct order.