### PR TITLE
Explicitly allow all capabilities required by SSSD in client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,11 @@ services:
     - AUDIT_CONTROL
     - SYS_CHROOT
     - NET_ADMIN
+    - CAP_CHOWN
+    - CAP_DAC_OVERRIDE
+    - CAP_SETGID
+    - CAP_SETUID
+    - CAP_DAC_READ_SEARCH
     security_opt:
     - apparmor=unconfined
     - label=disable
@@ -98,6 +103,11 @@ services:
     - AUDIT_WRITE
     - AUDIT_CONTROL
     - SYS_CHROOT
+    - CAP_CHOWN
+    - CAP_DAC_OVERRIDE
+    - CAP_SETGID
+    - CAP_SETUID
+    - CAP_DAC_READ_SEARCH
     security_opt:
     - apparmor=unconfined
     - label=disable


### PR DESCRIPTION
and IPA containers.
Currently only 'CAP_DAC_READ_SEARCH' was missing, so probably other were added by default. But it is more clear to list everything explicitly.