### PR TITLE
Match roles against host groups, tweak ssh server.

### DIFF
--- a/src/ansible/playbook_image_service.yml
+++ b/src/ansible/playbook_image_service.yml
@@ -6,40 +6,40 @@
   - firewall
   - no_nscd
 
-- hosts: master.ldap.test
+- hosts: ldap
   gather_facts: no
   roles:
   - ldap
 
-- hosts: dc.samba.test
+- hosts: samba
   gather_facts: no
   roles:
   - samba
 
-- hosts: master.ipa.test
+- hosts: ipa
   gather_facts: no
   roles:
   - ipa
   - { role: passkey, when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" }
 
-- hosts: client.test
+- hosts: client
   gather_facts: no
   roles:
   - client
   - { role: passkey, when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian" }
   - { role: virtsmartcard, when: ansible_distribution != "Ubuntu" and ansible_distribution != "Debian" and virt_smartcard }
 
-- hosts: nfs.test
+- hosts: nfs
   gather_facts: no
   roles:
   - nfs
 
-- hosts: kdc.test
+- hosts: kdc
   gather_facts: no
   roles:
   - kdc
 
-- hosts: master.keycloak.test
+- hosts: keycloak
   gather_facts: no
   roles:
   - keycloak

--- a/src/ansible/roles/ssh_server/tasks/main.yml
+++ b/src/ansible/roles/ssh_server/tasks/main.yml
@@ -1,10 +1,26 @@
-- name: Configure SSH daemon
+- name: Check if we have pre-generated key
+  ansible.builtin.stat:
+    path: "/data/ssh-keys/hosts/{{ inventory_hostname }}.ecdsa_key"
+  register: stat_ecdsa_key
+
+- name: Configure SSH daemon with pre-generated hostkey
   template:
     src: sshd.conf
     dest: /etc/ssh/sshd_config.d
     owner: root
     group: root
     mode: 0600
+  when: stat_ecdsa_key.stat.exists
+
+- name: Configure SSH daemon without pre-generated hostkey
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config.d/sshd.conf
+    owner: root
+    group: root
+    mode: 0600
+    content: |
+      PermitRootLogin yes
+  when: not stat_ecdsa_key.stat.exists
 
 - name: Start SSH daemon
   service:


### PR DESCRIPTION
Run roles against host groups instead of hostnames as a preparation for extending the topologies.
Make sure ssh is not broken for ad-hoc added machines referencing non-existent host keys.