### PR TITLE
provision: Add binutils to have strings available on client

### DIFF
--- a/src/ansible/roles/packages/tasks/Debian.yml
+++ b/src/ansible/roles/packages/tasks/Debian.yml
@@ -70,6 +70,7 @@
       update_cache: yes
       name:
       - augeas-tools
+      - binutils
   when: "'base_client' in group_names or 'client' in group_names"
 
 - name: Install packages for NFS base image

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -174,6 +174,7 @@
       - nss-pam-ldapd
       - tcpdump
       - wireshark-cli
+      - binutils
       disable_gpg_check: yes
 
   - name: Install packages for virtual smartcard from general repos

--- a/src/ansible/roles/packages/tasks/Ubuntu.yml
+++ b/src/ansible/roles/packages/tasks/Ubuntu.yml
@@ -60,6 +60,7 @@
       update_cache: yes
       name:
       - augeas-tools
+      - binutils
   - name: Install packages required for passkey testing
     apt:
       state: present


### PR DESCRIPTION
Strings command is used in feature detection on client but binutils providing it are by default missing in containers.