### PR TITLE
keycloak: add KC_HTTPS_TRUST_STORE_TYPE

### DIFF
--- a/src/ansible/roles/keycloak/tasks/main.yml
+++ b/src/ansible/roles/keycloak/tasks/main.yml
@@ -63,6 +63,7 @@
     export KC_HTTPS_CERTIFICATE_KEY_FILE=/data/certs/master.keycloak.test.key
     export KC_HTTPS_TRUST_STORE_FILE=/data/certs/master.keycloak.test.keystore
     export KC_HTTPS_TRUST_STORE_PASSWORD={{ service.keycloak.admin_password }}
+    export KC_HTTPS_TRUST_STORE_TYPE=JKS
     export KC_HTTP_RELATIVE_PATH=/auth
     /opt/keycloak/bin/kc.sh build
     '''
@@ -77,6 +78,7 @@
       KC_HTTPS_CERTIFICATE_KEY_FILE=/data/certs/master.keycloak.test.key
       KC_HTTPS_TRUST_STORE_FILE=/data/certs/master.keycloak.test.keystore
       KC_HTTPS_TRUST_STORE_PASSWORD={{ service.keycloak.admin_password }}
+      KC_HTTPS_TRUST_STORE_TYPE=JKS
       KC_HTTP_RELATIVE_PATH=/auth
     dest: /etc/keycloak.env
 


### PR DESCRIPTION
It looks like recent version of keycloak require that the
KC_HTTPS_TRUST_STORE_TYPE environment variable is set. Otherwise an
error like "kc.sh[54]: Unable to determine 'https-trust-store-type'
automatically. Adjust the file extension or specify the property." might
occur and keycloak fails to start.