### PR TITLE
provision: update java-17-openjdk-headless to 21

### DIFF
--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -274,7 +274,7 @@
       state: present
       allowerasing: true
       name:
-      - java-17-openjdk-headless
+      - java-21-openjdk-headless
       - openssl
       - unzip
       - curl


### PR DESCRIPTION
java-17-openjdk-headless is dropped in Centos10 and RHEL10.  Switching to java-21-openjdk-headless for Keycloak.