### PR TITLE
Retry IPA client install

### DIFF
--- a/src/ansible/roles/client/tasks/enroll_IPA.yml
+++ b/src/ansible/roles/client/tasks/enroll_IPA.yml
@@ -11,6 +11,10 @@
       --domain {{ ipa_domain | quote }}                \
       --principal admin                                \
       --password {{ ipa_password | quote }}
+  # Retry to workaround "Unable to find IPA Server to join" failure (fedora-42)
+  # in PRCI fedora build workflow
+  retries: 2
+  delay: 10
   args:
     creates: /etc/ipa/ca.crt
 


### PR DESCRIPTION
ipa-client-install with TAG=fedora-42 can fail in PRCI with
"Unable to find IPA Server to join" although SRV records are
present and valid.

```
- 2024-11-20T21:15:38Z DEBUG [IPA Discovery]
- 2024-11-20T21:15:38Z DEBUG Starting IPA discovery with domain=ipa.test, servers=None, hostname=client.test
- 2024-11-20T21:15:38Z DEBUG Search for LDAP SRV record in ipa.test
- 2024-11-20T21:15:38Z DEBUG Search DNS for SRV record of _ldap._tcp.ipa.test
- 2024-11-20T21:15:38Z DEBUG DNS record not found: NXDOMAIN'
- 2024-11-20T21:15:38Z DEBUG No LDAP server found
```