### PR TITLE
ci: fix link for package to workaround networking issue

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -39,9 +39,9 @@ runs:
   - name: Workaround https://github.com/actions/runner-images/issues/7753
     shell: bash
     run: |
-      curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3_amd64.deb
-      sudo dpkg -i containernetworking-plugins_1.1.1+ds1-3_amd64.deb
-      rm --force containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+      curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3ubuntu0.24.04.2_amd64.deb
+      sudo dpkg -i containernetworking-plugins_1.1.1+ds1-3ubuntu0.24.04.2_amd64.deb
+      rm --force containernetworking-plugins_1.1.1+ds1-3ubuntu0.24.04.2_amd64.deb
 
   - name: Workaround https://github.com/containers/crun/issues/1308
     shell: bash


### PR DESCRIPTION
The original link is no longer available.