### PR TITLE
Update for multiarch testing

### DIFF
--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -129,6 +129,7 @@
       - adcli
       - sssd
       - 'sssd-*'
+      disablerepo: 'beaker-tasks'
     register: pkg_install
 
   - name: Check installed packages
@@ -137,7 +138,7 @@
   # ansible dnf5 seems to have a regression with wildcard *
   # https://github.com/ansible/ansible/issues/83373
   - name: Install sssd subpackages
-    command: yum install -y 'sssd-*'
+    command: yum install -y 'sssd-*' --disablerepo=beaker-tasks
     register: sssd_install
     when: "'sssd-ad' not in ansible_facts.packages or 'sssd-kcm' not in ansible_facts.packages"
 

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -62,6 +62,7 @@
       - python3-pip
       - sudo
       - systemd
+      - rsync
       disable_gpg_check: yes
   when: "'base_ground' in group_names"
 


### PR DESCRIPTION
We need to disable beaker tasks repo for sssd package installation to prevent stray package inclusion.
Rsync is missing from RHEL 10.0 aarch64 and needs to be explicitly installed for common role.