### PR TITLE
dns: Make ipa reverse zones inclusion in dns config optional

### DIFF
--- a/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
+++ b/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
@@ -27,8 +27,10 @@ server=/{{ hostvars[ad]['ansible_facts']['windows_domain'] }}/{{ hostvars[ad]['a
 {% endfor %}
 {% endif %}
 
+{% if 'master.ipa.test' in hostvars %}
 # Add reverse zones for artificial hosts in IPA domain
 server=/251.255.10.in-addr.arpa/{{ hostvars['master.ipa.test']['ansible_facts']['default_ipv4']['address'] }}
+{% endif %}
 
 # Add SRV record for LDAP
 {% if 'master.ldap.test' in hostvars %}


### PR DESCRIPTION
The record for reverse zone was hardcoded in dns config instead of being added only when needed.