### PR TITLE
fix vagrant build and AD provisioning

### DIFF
--- a/src/Containerfile
+++ b/src/Containerfile
@@ -4,7 +4,7 @@ RUN apk --no-cache add dnsmasq
 ENTRYPOINT ["dnsmasq", "-k"]
 
 # vagrant with preinstalled plugins and ansible
-FROM ubuntu:latest as vagrant-base
+FROM debian:latest as vagrant-base
 ENV VAGRANT_HOME /vagrant
 ENV VAGRANT_DEFAULT_PROVIDER=libvirt
 RUN mkdir /vagrant
@@ -29,7 +29,7 @@ RUN set -e \
 
 FROM vagrant-base as vagrant-plugins
 WORKDIR /build
-RUN sed -i '/deb-src/s/^# //' /etc/apt/sources.list
+RUN sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/debian.sources
 RUN set -e \
     && apt update && apt build-dep -y vagrant ruby-libvirt \
     && apt install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev \
@@ -40,4 +40,4 @@ RUN vagrant plugin install vagrant-sshfs
 FROM vagrant-base as vagrant
 ENTRYPOINT ["/usr/bin/bash"]
 COPY --from=vagrant-plugins /vagrant /vagrant
-RUN pip3 install ansible pywinrm
+RUN pip3 install ansible pywinrm --break-system-packages

--- a/src/ansible/inventory.yml
+++ b/src/ansible/inventory.yml
@@ -85,5 +85,5 @@ all:
       vars:
         ansible_connection: winrm
         ansible_port: 5985
-        ansible_user: .\Administrator
+        ansible_user: Administrator
         ansible_password: vagrant


### PR DESCRIPTION
```
381aac5 (Pavel Březina, 2 minutes ago)
   provision: fix AD credentials in inventory

   For some reason, `.\Administrator` is no longer working. This format should
   allowed both plain Administrator and Administrator from AD domain to login
   with the same inventory file, but authentication just fails with it now.

   On the other hand, while this was required before, it does not seem to be
   required now as the provisioning works without the dot.

986808b (Pavel Březina, 4 minutes ago)
   vagrant: fix vagrant build

   The apt changed the location and contents of sources configuration file.

   Ubuntu no longer ships vagrant therefore it was not possible to install its
   build dependencies with build-dep command.

   Now we build vagrant on debian instead of ubuntu, with required changes.
```