### PR TITLE
Skip ipasmartcard on client if not joined to IPA

### DIFF
--- a/src/ansible/group_vars/all
+++ b/src/ansible/group_vars/all
@@ -82,7 +82,7 @@ trust_ipa_samba: yes
 trust_ipa_ad: no
 trust_ipa_ad_two_way: no
 extended_packageset: yes
-virt_smartcard: yes
+virt_smartcard: no
 virt_smartcard_dir: /opt/test_ca
 virt_smartcard_sopin: 12345678
 virt_smartcard_pin: 123456

--- a/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
+++ b/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
@@ -14,7 +14,7 @@ cache-size=0
 
 # These zones have their own DNS server
 {% for host in groups['ipa'] %}
-server=/{{ hostvars[host]['ansible_facts']['domain'] }}/{{ hostvars[host]['ansible_facts']['default_ipv4']['address'] }}
+server=/{{ '.'.join(hostvars[host].inventory_hostname.split('.')[1:]) }}/{{ hostvars[host]['ansible_facts']['default_ipv4']['address'] }}
 {% endfor %}
 {% if 'dc.samba.test' in hostvars %}
 server=/samba.test/{{ hostvars['dc.samba.test']['ansible_facts']['default_ipv4']['address'] }}

--- a/src/ansible/roles/facts/tasks/CentOS10.yml
+++ b/src/ansible/roles/facts/tasks/CentOS10.yml
@@ -5,4 +5,4 @@
   set_fact:
     buildroot: Yes
     passkey_support: Yes
-    virt_smartcard: Yes
+    virt_smartcard: No

--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -112,6 +112,16 @@
     stdin: '{{ ipa_password }}'
   when: inventory_hostname == 'master.ipa.test'
 
+# Workaround to make sure the IPA DNS server starts cleanly after install
+# https://issues.redhat.com/browse/RHEL-63017
+- name: Checking DNS resolution is working
+  shell: |
+    dig ipa-ca.{{ ipa_domain }} | grep NOERROR
+  register: result
+  until: result.rc == 0
+  retries: 60
+  delay: 2
+
 - name: 'Check trust with other domains'
   shell: |
     kinit admin

--- a/src/ansible/roles/ipasmartcard/tasks/main.yml
+++ b/src/ansible/roles/ipasmartcard/tasks/main.yml
@@ -1,11 +1,3 @@
-- name: Checking DNS resolution first
-  shell: |
-    dig ipa-ca.{{ ipa_domain }} | grep NOERROR
-  register: result
-  until: result.rc == 0
-  retries: 10
-  delay: 2
-
 - name: Make sure virtual smartcard dir exists
   file:
     path: "{{ virt_smartcard_dir }}"
@@ -72,4 +64,7 @@
     file:
       path: /etc/krb5.keytab
       state: absent
-  when: inventory_hostname == groups.client.0
+  when:
+  - inventory_hostname == groups.client.0
+  - join_ipa
+  - virt_smartcard


### PR DESCRIPTION
When configured using playbook_vm.yaml, the client is not enrolled in IPA by default.  This causes the ipasmartcard role to currently fail to find the IPA kerberos keytab needed.   The client side setup can be skipped in the case where the system is not enrolled to IPA.