### PR TITLE
Add ANSIBLE_OPTS when running playbook_image_base

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -103,7 +103,7 @@ function build_base_image {
     c8s_repo
     base_install_python
   fi
-  ansible-playbook --limit "`echo $name | sed -r 's/-/_/g'`" ./ansible/playbook_image_base.yml
+  ansible-playbook $ANSIBLE_OPTS --limit "`echo $name | sed -r 's/-/_/g'`" ./ansible/playbook_image_base.yml
   ${DOCKER} stop sssd-wip-base
   ${DOCKER} commit                     \
     --change 'CMD ["/sbin/init"]'      \


### PR DESCRIPTION
Adding ANSIBLE_OPTS to the ansible-playbook command that runs
playbook_image_base.yaml in build.sh.   This is needed to set specific
variables needed during the base playbook like virt_smartcard that is
used to install packages specific to smart card tests.