### PR TITLE
 moving ipa2 to a second subnet 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ up-keycloak:
 	docker-compose -f docker-compose.yml up \
 	--no-recreate --detach ${LIMIT}
 
+start:
+	docker-compose start
+
 stop:
 	docker-compose stop
 

--- a/data/configs/dnsmasq.conf
+++ b/data/configs/dnsmasq.conf
@@ -12,7 +12,7 @@ cache-size=0
 
 # These zones have their own DNS server
 server=/ipa.test/172.16.100.10
-server=/ipa2.test/172.16.100.11
+server=/ipa2.test/172.16.110.10
 server=/samba.test/172.16.100.30
 server=/ad.test/172.16.200.10
 
@@ -36,4 +36,4 @@ ptr-record=30.100.16.172.in-addr.arpa,dc.samba.test
 ptr-record=40.100.16.172.in-addr.arpa,client.test
 ptr-record=10.200.16.172.in-addr.arpa,dc.ad.test
 ptr-record=70.100.16.172.in-addr.arpa,master.keycloak.test
-ptr-record=80.100.16.172.in-addr.arpa,master.ipa2.test
+ptr-record=10.110.16.172.in-addr.arpa,master.ipa2.test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,8 @@ services:
     - label=disable
     - seccomp=unconfined
     networks:
-      sssd:
-        ipv4_address: 172.16.100.11
+      ipa:
+        ipv4_address: 172.16.110.10
   ldap:
     image: ${REGISTRY}/ci-ldap:${TAG}
     container_name: ldap
@@ -212,10 +212,7 @@ services:
 networks:
   sssd:
     name: sssd-ci
-    driver: bridge
-    ipam:
-     config:
-       - subnet: 172.16.100.0/24
-         gateway: 172.16.100.1
-     options:
-        driver: host-local
+    external: true
+  ipa:
+    name: ipa-ci
+    external: true

--- a/src/build.sh
+++ b/src/build.sh
@@ -50,7 +50,15 @@ function cleanup {
 }
 
 function compose {
-  docker-compose -f "../docker-compose.yml" -f "./docker-compose.build.yml" $@
+  if [ $@ == "up" ]; then
+    ./tools/create-networks.sh
+    docker-compose -f "../docker-compose.yml" -f "./docker-compose.build.yml" $@ --detach
+  elif [ "$@" == "down" ]; then
+    docker-compose -f "../docker-compose.yml" -f "./docker-compose.build.yml" $@
+    ./tools/remove-networks.sh
+  else
+    docker-compose -f "../docker-compose.yml" -f "./docker-compose.build.yml" $@
+  fi
 }
 
 function base_exec {
@@ -128,7 +136,7 @@ if [ "$SKIP_BASE" == 'no' ]; then
 fi
 
 # Create services
-compose up --detach
+compose up
 ansible-playbook $ANSIBLE_OPTS ./ansible/playbook_image_service.yml
 compose stop
 build_service_image sssd-wip-client client

--- a/src/tools/create-networks.sh
+++ b/src/tools/create-networks.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Create sssd-ci networks.
+#
+# Networks created using docker-compose sets 'isolation = true', making hosts
+# in other networks unroutable. A workaround is to create the networks using
+# the docker command and define the network as external in docker-compose.
+#
+# Usage:
+#   create-networks.sh
+#
+
+default=docker
+if which podman &> /dev/null; then
+  default=podman
+fi
+
+export DOCKER="${DOCKER:-$default}"
+
+echo "Creating networks..."
+
+${DOCKER} network inspect sssd-ci &> /dev/null ||
+    ${DOCKER} network create \
+        --driver bridge \
+        --subnet 172.16.100.0/24 \
+        --gateway 172.16.100.1 \
+        sssd-ci
+${DOCKER} network inspect ipa-ci &> /dev/null ||
+    ${DOCKER} network create  \
+        --driver bridge \
+        --subnet 172.16.110.0/24 \
+        --gateway 172.16.110.1 \
+        ipa-ci

--- a/src/tools/remove-networks.sh
+++ b/src/tools/remove-networks.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Remove sssd-ci networks.
+#
+# Usage:
+#   remove-networks.sh
+#
+
+default=docker
+if which podman &> /dev/null; then
+  default=podman
+fi
+
+export DOCKER="${DOCKER:-$default}"
+
+${DOCKER} network rm ipa-ci -f
+${DOCKER} network rm sssd-ci -f

--- a/src/tools/setup-dns-files.sh
+++ b/src/tools/setup-dns-files.sh
@@ -29,4 +29,4 @@ echo "172.16.100.50 nfs.test" >> /etc/hosts
 echo "172.16.100.60 kdc.test" >> /etc/hosts
 echo "172.16.100.70 master.keycloak.test" >> /etc/hosts
 echo "172.16.200.10 dc.ad.test" >> /etc/hosts
-echo "172.16.100.11 master.ipa2.test" >> /etc/hosts
+echo "172.16.110.10 master.ipa2.test" >> /etc/hosts


### PR DESCRIPTION
* making this environment more realistic
* moved the network create to use the docker command because docker-compose defaults the isolation value to true
