### PR TITLE
ad: setting the version of psini module as a requirement

### DIFF
--- a/src/ansible/roles/ad/tasks/main.yml
+++ b/src/ansible/roles/ad/tasks/main.yml
@@ -57,7 +57,7 @@
   win_shell: |
     Get-PackageProvider NuGet -ForceBootstrap
     Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
-    Install-Module PSIni -Confirm:$False
+    Install-Module PSIni -RequiredVersion 3.1.4 -Confirm:$False
 
 - name: Make sure Active Directory Web Services is running
   win_service:


### PR DESCRIPTION
* the methods changed in their major release of PSIni 4.0 and the methods used in the test no longer exist.