### PR TITLE
Enable virt_smartcard for centos10

### DIFF
--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -11,7 +11,7 @@
     user_regular_uid: 1024
     ansible_become: yes
     extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
-    virt_smarcard: "{{ override_virt_smarcard | default('no') | bool }}"
+    virt_smartcard: "{{ override_virt_smartcard | default('no') | bool }}"
 
 - name: Include services
   ansible.builtin.import_playbook: playbook_image_service.yml
@@ -28,7 +28,7 @@
     trust_ipa_ad_two_way: "{{ override_trust_ipa_ad_two_way | default('no') | bool }}"
     extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
     skip_cleanup: true
-    virt_smarcard: "{{ override_virt_smarcard | default('no') | bool }}"
+    virt_smartcard: "{{ override_virt_smartcard | default('no') | bool }}"
 
 - hosts: ad
   gather_facts: yes

--- a/src/ansible/roles/facts/tasks/CentOS10.yml
+++ b/src/ansible/roles/facts/tasks/CentOS10.yml
@@ -5,4 +5,3 @@
   set_fact:
     buildroot: Yes
     passkey_support: Yes
-    virt_smartcard: No


### PR DESCRIPTION
virt_smartcard was explicitly disabled for Centos 10 setup.   This needs
to be enabled so that the centos10 system tests can run smart card tests
in PR-CI.   Removing this from the Centos10 specific facts task file.

Also fix a virt_smartcard typo in playbook_vm.yml