### PR TITLE
IPA role: NetBIOS domain name

### DIFF
--- a/src/ansible/roles/ad/tasks/main.yml
+++ b/src/ansible/roles/ad/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Prepare AD facts
   set_fact:
     ad_domain: "{{ '.'.join(inventory_hostname.split('.')[1:]) }}"
-    ad_netbios: "{{ inventory_hostname.split('.')[0].upper() }}"
+    ad_netbios: "{{ inventory_hostname.split('.')[1].upper() }}"
     ad_suffix: "{{ inventory_hostname.split('.')[1:] | map('regex_replace', '^(.*)$', 'dc=\\1') | join(',') }}"
     ad_password: "{{ service.ad.safe_password }}"
 

--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Prepare IPA facts
   set_fact:
     ipa_domain: "{{ '.'.join(inventory_hostname.split('.')[1:]) }}"
-    ipa_netbios: "{{ inventory_hostname.split('.')[0].upper() }}"
+    ipa_netbios: "{{ inventory_hostname.split('.')[1].upper() }}"
     ipa_suffix: "{{ inventory_hostname.split('.')[1:] | map('regex_replace', '^(.*)$', 'dc=\\1') | join(',') }}"
     ipa_password: "{{ ansible_password | default(service.ipa.password)  }}"
 


### PR DESCRIPTION
Use the second component of the fully-qualified domain name of the IPA 
server as value for the --netbios-name option. This option sets the NetBIOS
name of the IPA domain so the most specific domain component of the
hostname is the better fit. Additionally, with the current setting both IPA
domains have the same NetBIOS name ('MASTER') which prevents the creation
of trust between the two domains.