### PR TITLE
disabling ad dns scavenging

### DIFF
--- a/src/ansible/roles/ad/tasks/main.yml
+++ b/src/ansible/roles/ad/tasks/main.yml
@@ -65,6 +65,10 @@
     start_mode: auto
     state: started
 
+- name: Disable AD DNS Scavenger
+  win_shell: |
+    Set-DnsServerScavenging $false
+
 - name: 'Add sudo schema and possibly other'
   include_tasks: 'schema.yml'
   when: not skip_schema


### PR DESCRIPTION
when this feature is enabledk, dns records that have been removed by ldap operations during host restore are inconsistent.