### PR TITLE
AD role: Fix a boostrap error installing NuGet

### DIFF
--- a/src/ansible/roles/ad/tasks/main.yml
+++ b/src/ansible/roles/ad/tasks/main.yml
@@ -61,6 +61,7 @@
 
 - name: Install powershell modules
   win_shell: |
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Get-PackageProvider NuGet -ForceBootstrap
     Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
     Install-Module PSIni -RequiredVersion 3.1.4 -Confirm:$False


### PR DESCRIPTION
Deploying AD with steps from https://github.com/sssd/sssd-ci-containers?tab=readme-ov-file#using-real-active-directory-instance fails at the `Install powershell modules` step due to https://devblogs.microsoft.com/powershell/when-powershellget-v1-fails-to-install-the-nuget-provider/

Adding the step in this PR fixes the issue for me.