### PR TITLE
Revert "Drop support for CentOS 8"

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -10,7 +10,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: Install python packages with older ansible for Centos 8
+    if: ${{ inputs.tag == 'centos-8' }}
+    shell: bash
+    run: |
+      sudo pip3 install ansible==9.8 passlib
+
   - name: Install python packages
+    if: ${{ inputs.tag != 'centos-8' }}
     shell: bash
     run: |
       sudo pip3 install ansible passlib

--- a/src/ansible/filter_plugins/distro.py
+++ b/src/ansible/filter_plugins/distro.py
@@ -10,7 +10,8 @@ class FilterModule(object):
         if distro.lower() == 'fedora':
             min_version = 34
         elif distro.lower() == 'centos':
-            min_version = 9
+            # RHEL 8.x and Centos Strem 8 are the same, keep this around for now!
+            min_version = 8
 
         out = [f'{distro}{extra}.yml']
         out.extend([ f'{distro}{x}{extra}.yml' for x in range(min_version, int(version) + 1) ])

--- a/src/ansible/roles/facts/tasks/CentOS8.yml
+++ b/src/ansible/roles/facts/tasks/CentOS8.yml
@@ -1,3 +1,5 @@
+# RHEL 8.x and Centos Strem 8 are the same, keep this around for now!
+
 - name: 'Facts are the same as in Fedora'
   include_tasks: 'Fedora.yml'
 

--- a/src/ansible/roles/packages/tasks/CentOS8.yml
+++ b/src/ansible/roles/packages/tasks/CentOS8.yml
@@ -1,0 +1,33 @@
+- name: Install buildroot repository
+  block:
+  - name: Install dnf plugins
+    dnf:
+      state: present
+      name:
+      - dnf-plugins-core
+
+  - name: Install additional repos
+    template:
+      src: repo
+      dest: '/etc/yum.repos.d/{{ item.name }}.repo'
+      owner: root
+      group: root
+      mode: 0644
+    with_items:
+    - {name: 'buildroot', url: 'https://kojihub.stream.centos.org/kojifiles/repos/c8s-build/latest/$basearch'}
+    - {name: 'crb', url: 'http://vault.centos.org/centos/8-stream/PowerTools/$basearch/os/'}
+    when: buildroot
+
+  - name: Install EPEL repository
+    dnf:
+      state: present
+      name:
+      - epel-release
+
+  - name: Enable IdM module
+    shell: |
+      dnf module enable -y idm:DL1
+  when: "'base_ground' in group_names"
+
+- name: 'Packages are the same as in Fedora'
+  include_tasks: 'Fedora.yml'


### PR DESCRIPTION
This reverts commit 6ee5fb70923012ee750e8de769ed68e47199c3b1.

 We can't drop support for centos 8 as the ci is used also for RHEL 8  which is still supported.