### PR TITLE
dns: Add a dns server for redhat domain in idmci

### DIFF
--- a/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
+++ b/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
@@ -12,6 +12,9 @@ domain=test
 # Disable caching so we always query AD and IPA DNS
 cache-size=0
 
+# RH DNS Server
+server=/redhat.com/10.11.5.19
+
 # These zones have their own DNS server
 {% for host in groups['ipa'] %}
 server=/{{ '.'.join(hostvars[host].inventory_hostname.split('.')[1:]) }}/{{ hostvars[host]['ansible_facts']['default_ipv4']['address'] }}


### PR DESCRIPTION
Dnsmasq seems to have an issue with upstream dns servers in aws. This adds a fixed upstream server for redhat domain.