### PR TITLE
packages: Return passwd needed for Centos 8 and Centos 9

### DIFF
--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -71,6 +71,7 @@
       - shadow-utils-subid
       - sudo
       - rsync
+      - passwd
       disable_gpg_check: yes
   when: "'base_ground' in group_names"
 


### PR DESCRIPTION
Partially reverts eace5732849bbbbae646f71cc3266c9e89870dfd.

The passwd is missing in Centos 9 containers failing tests like this:

FAILED tests/test_basic.py::test_basic__single_user (bare_client) - pytest_mh.conn.ssh.SSHProcessError: 
Command #21 exited with return code 127:
  Command:
    useradd 'user-1' && passwd --stdin 'user-1'
  CWD:
  Env:
  Output:
  Error output:
    bash: line 1: passwd: command not found
