### PR TITLE
ipa: Remove leftover kerberos TGT

### DIFF
--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -197,3 +197,9 @@
   - join_ad
   - trust_ipa_ad
   - inventory_hostname != 'master.ipa2.test'
+
+# Leftover TGT from kinit above can cause sasl bind failures such as
+# (Server ldap/dc.samba.test@IPA.TEST not found in Kerberos database)
+- name: Destroy any remaining kerberos TGT
+  command: kdestroy -A
+  failed_when: false

--- a/src/ansible/roles/ipasmartcard/tasks/main.yml
+++ b/src/ansible/roles/ipasmartcard/tasks/main.yml
@@ -23,6 +23,10 @@
     ansible.builtin.systemd_service:
       name: httpd
       state: restarted
+
+  - name: Destroy any remaining kerberos TGT
+    command: kdestroy -A
+    failed_when: false
   when: inventory_hostname == groups.ipa.0
 
 - block:
@@ -64,6 +68,10 @@
     file:
       path: /etc/krb5.keytab
       state: absent
+
+  - name: Destroy any remaining kerberos TGT
+    command: kdestroy -A
+    failed_when: false
   when:
   - inventory_hostname == groups.client.0
   - join_ipa


### PR DESCRIPTION
Containers are being built and published with existing 'admin' IPA TGT in the root user KCM ccache. Local test runs can fail when executing tests from other topologies if IPA.TEST TGT is detected in kerberos cache.

```
justin@justin-fedora:~/github/sssd-ci-containers$ sudo make down && sudo make update && sudo make up
justin@justin-fedora:~/github/sssd-ci-containers$ sudo podman exec -it client klist
Ticket cache: KCM:0
Default principal: admin@IPA.TEST

Valid starting     Expires            Service principal
04/21/26 04:49:48  04/22/26 04:39:14  krbtgt/IPA.TEST@IPA.TEST
```

```
justin@justin-fedora:~/github/sssd/src/tests/system$ rm -f mh-debug.log && rm -rf artifacts/tests/* && pytest --mh-config=mhc.yaml --mh-lazy-ssh --mh-log-path=mh-debug.log -v -k "test_access_filter__single_ldap_attribute_permits_user_login" --mh-topology=samba
============================= short test summary info ==============================                                                                                     
FAILED tests/test_access_control_ldap_filter.py::test_access_filter__single_ldap_attribute_permits_user_login (samba) - AssertionError: `user1` should be able to login! 
======================== 1 failed, 985 deselected in 28.07s ========================                                                                              
```

-- In the SSSD samba domain log

```
[sasl_bind_send] (0x0100): Executing sasl bind mech: GSS-SPNEGO, user: CLIENT$
[ad_sasl_log] (0x0040): SASL: GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Server ldap/dc.samba.test@IPA.TEST not found in Kerberos database)
[sss_ldap_error_debug] (0x0020): ldap_sasl_interactive_bind_s failed: 'Local error' ('SASL(-1): generic failure: GSSAPI Error: Unspecified GSS failure.  Minor code may provide more information (Server ldap/dc.samba.test@IPA.TEST not found in Kerberos database)')
```