### PR TITLE
DNS: fix dns server dnsmasq template

### DIFF
--- a/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
+++ b/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
@@ -19,34 +19,30 @@ server=/redhat.com/10.11.5.19
 {% for host in groups['ipa'] %}
 server=/{{ '.'.join(hostvars[host].inventory_hostname.split('.')[1:]) }}/{{ hostvars[host]['ansible_facts']['default_ipv4']['address'] }}
 {% endfor %}
-{% if 'dc.samba.test' in hostvars %}
+{% if hostvars['dc.samba.test'] is defined %}
 server=/samba.test/{{ hostvars['dc.samba.test']['ansible_facts']['default_ipv4']['address'] }}
 {% endif %}
-{% if 'dc.ad.test' in hostvars %}
-server=/{{ hostvars[ad]['ansible_facts']['windows_domain'] }}/{{ hostvars['dc.ad.test']['ansible_facts']['ip_addresses'][0] }}
-{% elif 'ad' in groups and groups['ad'] %}
-{% for ad in groups['ad'] %}
-server=/{{ hostvars[ad]['ansible_facts']['windows_domain'] }}/{{ hostvars[ad]['ansible_facts']['ip_addresses'][0] }}
+{% if groups['ad'] is defined and groups['ad'] | length > 0 %}
+{% for ad_host in groups['ad'] %}
+server=/{{ hostvars[ad_host]['ansible_facts']['windows_domain'] }}/{{ hostvars[ad_host]['ansible_facts']['ip_addresses'][0] }}
 {% endfor %}
 {% endif %}
 
 # Add reverse zones for artificial hosts
-{% if 'master.ipa.test' in hostvars %}
+{% if hostvars['master.ipa.test'] is defined %}
 rev-server=10.255.251.0/24,{{ hostvars['master.ipa.test']['ansible_facts']['default_ipv4']['address'] }}
 {% endif %}
-{% if 'dc.samba.test' in hostvars %}
+{% if hostvars['dc.samba.test'] is defined %}
 rev-server=10.255.252.0/24,{{ hostvars['dc.samba.test']['ansible_facts']['default_ipv4']['address'] }}
 {% endif %}
-{% if 'dc.ad.test' in hostvars %}
-rev-server=10.255.250.0/24,{{ hostvars['dc.ad.test']['ansible_facts']['default_ipv4']['address'] }}
-{% elif 'ad' in groups and groups['ad'] %}
-{% for ad in groups['ad'] %}
-rev-server=10.255.250.0/24,{{ hostvars[ad]['ansible_facts']['ip_addresses'][0] }}
+{% if groups['ad'] is defined and groups['ad'] | length > 0 %}
+{% for ad_host in groups['ad'] %}
+rev-server=10.255.250.0/24,{{ hostvars[ad_host]['ansible_facts']['ip_addresses'][0] }}
 {% endfor %}
 {% endif %}
 
 # Add SRV record records
-{% if 'master.ldap.test' in hostvars %}
+{% if hostvars['master.ldap.test'] is defined %}
 srv-host=_ldap._tcp.ldap.test,master.ldap.test,389
 {% endif %}
 


### PR DESCRIPTION
Modifying the "dns" role's dnsmasq.conf template file to check for 
existance of some of the groups to better avoid undefined variable
errors.
    
It should be noted that this change should not affect upstream PRCI
tests as those currently rely on static configs for the containers.
    
This is used for provisioning test environments with VMs and configuring
them to function like the containers.