### PR TITLE
copr: use global and conditional build timestamp

### DIFF
--- a/src/rpms/ci-sssd.spec
+++ b/src/rpms/ci-sssd.spec
@@ -1,4 +1,4 @@
-%define build_timestamp %(date +"%%Y_%%m_%%d_%%H_%%M_%%S")
+%{!?build_timestamp:%global build_timestamp %(date +"%%Y_%%m_%%d_%%H_%%M_%%S")}
 
 Name:           ci-sssd
 Version:        1


### PR DESCRIPTION
Fix failing @sssd/ci-deps COPR build

COPR make_srpm task trigged for @sssd/ci-deps COPR build can create multiple srpms with different second timestamps which leads to the error:

`ERROR: Expected to find single rebuilt srpm, found 2 in /var/lib/mock/fedora-44-x86_64-1778572450.118220/root//builddir/build/SRPMS/*src.rpm`


From https://download.copr.fedorainfracloud.org/results/@sssd/ci-deps/fedora-44-x86_64/10448303-ci-sssd/builder-live.log.gz

```
justin@justin-fedora:~/Downloads$ egrep -irn "Building|Wrote" builder-live.log
342: Buildsystem building group                                                                
971:Building target platforms: x86_64
972:Building for target x86_64
975:Wrote: /builddir/build/SRPMS/ci-sssd-1-2.fc44.2026_05_12_07_54_35.src.rpm
1019:Building target platforms: x86_64
1020:Building for target x86_64
1023:Wrote: /builddir/build/SRPMS/ci-sssd-1-2.fc44.2026_05_12_07_54_36.src.rpm
1083:Building target platforms: x86_64
1084:Building for target x86_64
1087:Wrote: /builddir/build/SRPMS/ci-sssd-1-2.fc44.2026_05_12_07_54_40.src.rpm
```