### PR TITLE
rpms: Use git describe for versioning ci-deps

### DIFF
--- a/src/rpms/Makefile
+++ b/src/rpms/Makefile
@@ -1,3 +1,13 @@
+set-version: prep
+	@dnf install -y git
+	@if git describe; then \
+		GIT_VERSION=$$(git describe | sed 's/-/_/g'); \
+		echo "Git describe succeeded. Version: $$GIT_VERSION"; \
+		sed -i "s/^Release:.*/Release: $$GIT_VERSION%{?dist}/" $(PWD)/rpmbuild/SPECS/ci-sssd.spec; \
+	else \
+		echo "Git describe failed with exit code $$?"; \
+	fi
+
 prep:
 	mkdir -p $(PWD)/rpmbuild/BUILD
 	mkdir -p $(PWD)/rpmbuild/RPMS
@@ -8,11 +18,11 @@ prep:
 	cp sss_pac_responder_client.c $(PWD)/rpmbuild/SOURCES
 	cp ci-sssd.spec $(PWD)/rpmbuild/SPECS
 
-srpm: prep
-	rpmbuild --define "_topdir $(PWD)/rpmbuild" -bs ci-sssd.spec
+srpm: set-version
+	rpmbuild --define "_topdir $(PWD)/rpmbuild" -bs $(PWD)/rpmbuild/SPECS/ci-sssd.spec
 
-rpms: prep
-	rpmbuild --define "_topdir $(PWD)/rpmbuild" -ba ci-sssd.spec
+rpms: set-version
+	rpmbuild --define "_topdir $(PWD)/rpmbuild" -ba $(PWD)/rpmbuild/SPECS/ci-sssd.spec
 
 clean:
 	rm -fr $(PWD)/rpmbuild

--- a/src/rpms/ci-sssd.spec
+++ b/src/rpms/ci-sssd.spec
@@ -1,8 +1,6 @@
-%{!?build_timestamp:%global build_timestamp %(date +"%%Y_%%m_%%d_%%H_%%M_%%S")}
-
 Name:           ci-sssd
 Version:        1
-Release:        2%{?dist}.%{build_timestamp}
+Release:        2%{?dist}
 Summary:        SSSD CI Packages
 URL:            https://github.com/SSSD/sssd-ci-containers
 


### PR DESCRIPTION
Workaround for https://github.com/fedora-copr/copr/issues/4065 which is caused by recent versions of mock performing multiple srpm builds.

Fix for failling ci-sssd builds of https://copr.fedorainfracloud.org/coprs/g/sssd/ci-deps/package/ci-sssd/