### PR TITLE
keycloak: add KC_HTTPS_CLIENT_AUTH=request

### DIFF
--- a/src/ansible/roles/keycloak/tasks/main.yml
+++ b/src/ansible/roles/keycloak/tasks/main.yml
@@ -79,6 +79,7 @@
     export KC_HTTPS_TRUST_STORE_FILE=/var/data/certs/master.keycloak.test.keystore
     export KC_HTTPS_TRUST_STORE_PASSWORD={{ service.keycloak.admin_password }}
     export KC_HTTPS_TRUST_STORE_TYPE=JKS
+    export KC_HTTPS_CLIENT_AUTH={{ service.keycloak.https_client_auth | default('request') }}
     export KC_HTTP_RELATIVE_PATH=/auth
     /opt/keycloak/bin/kc.sh build
     '''
@@ -94,6 +95,7 @@
       KC_HTTPS_TRUST_STORE_FILE=/var/data/certs/master.keycloak.test.keystore
       KC_HTTPS_TRUST_STORE_PASSWORD={{ service.keycloak.admin_password }}
       KC_HTTPS_TRUST_STORE_TYPE=JKS
+      KC_HTTPS_CLIENT_AUTH={{ service.keycloak.https_client_auth | default('request') }}
       KC_HTTP_RELATIVE_PATH=/auth
     dest: /etc/keycloak.env
 


### PR DESCRIPTION
By default keycloak does not care about client certificates send during the TLS handshake. With KC_HTTPS_CLIENT_AUTH=request keycloak will check the client certificate if it receives one. This is needs for mutual TLS (mTLS) as described in https://www.keycloak.org/server/mutual-tls.