### PR TITLE
ldap: fix certificate import on F45

### DIFF
--- a/src/ansible/roles/ldap/tasks/main.yml
+++ b/src/ansible/roles/ldap/tasks/main.yml
@@ -16,7 +16,15 @@
   shell: |
     dsconf localhost security ca-certificate add --file /var/data/certs/ca.crt --name "sssd-ca"
     dsconf localhost security ca-certificate set-trust-flags "sssd-ca" --flags "CT,,"
-    dsctl localhost tls import-server-key-cert /var/data/certs/master.ldap.test.crt /var/data/certs/master.ldap.test.key
+
+    ARGS=
+    # Check if --nickname parameter is supported and set it accordingly
+    # Workaround for https://github.com/389ds/389-ds-base/issues/7470
+    if dsctl localhost tls import-server-key-cert --help 2>&1 | grep -q -- '--nickname'; then
+      ARGS+='--nickname "Server-Cert"'
+    fi
+
+    dsctl localhost tls import-server-key-cert $ARGS /var/data/certs/master.ldap.test.crt /var/data/certs/master.ldap.test.key
 
 - name: Grant read-only anonymous access
   shell: |


### PR DESCRIPTION
--nickname should be optional, but if ommitted, it throws an error

```
Error: expected str, bytes or os.PathLike object, not NoneType
```

See: https://github.com/389ds/389-ds-base/issues/7470
