### PR TITLE
ldap: Remove quotes from Server-Cert nickname

### DIFF
--- a/src/ansible/roles/ldap/tasks/main.yml
+++ b/src/ansible/roles/ldap/tasks/main.yml
@@ -21,7 +21,7 @@
     # Check if --nickname parameter is supported and set it accordingly
     # Workaround for https://github.com/389ds/389-ds-base/issues/7470
     if dsctl localhost tls import-server-key-cert --help 2>&1 | grep -q -- '--nickname'; then
-      ARGS+='--nickname "Server-Cert"'
+      ARGS+='--nickname Server-Cert'
     fi
 
     dsctl localhost tls import-server-key-cert $ARGS /var/data/certs/master.ldap.test.crt /var/data/certs/master.ldap.test.key


### PR DESCRIPTION
Avoid 389ds creating a new server certificate with "" in the certificate nickname like "Server-Cert"