### PR TITLE
passkey: comment out starting vfido service

### DIFF
--- a/src/ansible/roles/passkey/tasks/main.yml
+++ b/src/ansible/roles/passkey/tasks/main.yml
@@ -49,11 +49,12 @@
       src: vfido.service
       dest: /etc/systemd/system
 
-  - name: Start vfido service
-    systemd_service:
-      name: vfido
-      daemon_reload: true
-      state: started
+# commented because log filling due to missing vhci_hcd module in some instances
+#  - name: Start vfido service
+#    systemd_service:
+#      name: vfido
+#      daemon_reload: true
+#      state: started
 
   - name: Clone virtual-fido to test_venv
     git:


### PR DESCRIPTION
In some instances vfido is started in an environment where it does not
properly function.   This is a workaround to skip starting it during
playbook runs using the passkey role.