### PR TITLE
passkey vfido.service remove - from ExecStartPre

### DIFF
--- a/src/ansible/roles/passkey/files/vfido.service
+++ b/src/ansible/roles/passkey/files/vfido.service
@@ -8,7 +8,7 @@ Group=root
 
 Environment=VAR=empty
 WorkingDirectory=/opt/test_venv/virtual-fido
-ExecStartPre=+-/usr/sbin/modprobe vhci-hcd
+ExecStartPre=+/bin/sh -c 'test -d /sys/module/vhci_hcd || modprobe vhci-hcd'
 ExecStart=nohup python3 /opt/test_venv/bin/vfido.py
 StandardOutput=append:/tmp/vfido.log
 StandardError=append:/tmp/vfido.log

--- a/src/ansible/roles/passkey/tasks/main.yml
+++ b/src/ansible/roles/passkey/tasks/main.yml
@@ -54,6 +54,7 @@
       name: vfido
       daemon_reload: true
       state: started
+    ignore_errors: yes
 
   - name: Clone virtual-fido to test_venv
     git:


### PR DESCRIPTION
The vfido.service unit file had ExecStartPre=+- to allow the modprobe to
fail silently.   This was causing a log file to fill because it could
not find the module in some setups.   Removing the - so that the
modprobe will cause the service to fail if it fails.