### PR TITLE
Passkey: Fix vfido resource limits by pre-compiling binary

### DIFF
--- a/src/ansible/roles/passkey/files/vfido.py
+++ b/src/ansible/roles/passkey/files/vfido.py
@@ -28,7 +28,8 @@ def run_demo():
     """Run in background"""
     global demo_process
 
-    cmd = ["go", "run", "./cmd/demo", "start"]
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    cmd = [os.path.join(script_dir, "vfido-demo"), "start"]
 
     print(f"Starting virtual-fido demo...")
     print(f"Command: {' '.join(cmd)}")
@@ -36,7 +37,6 @@ def run_demo():
     with open("/tmp/virtual-fido.out", "w") as f:
         demo_process = subprocess.Popen(
             cmd,
-            cwd="/opt/test_venv/virtual-fido",
             stdin=subprocess.PIPE,
             stdout=f,
             stderr=subprocess.STDOUT,

--- a/src/ansible/roles/passkey/files/vfido_pin_disable
+++ b/src/ansible/roles/passkey/files/vfido_pin_disable
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-pushd /opt/test_venv/virtual-fido
-/usr/bin/go run ./cmd/demo pin disable
+# Run in the virtual-fido directory where vault.json is stored
+cd /opt/test_venv/virtual-fido
+"$(dirname "$0")/vfido-demo" pin disable

--- a/src/ansible/roles/passkey/files/vfido_pin_enable
+++ b/src/ansible/roles/passkey/files/vfido_pin_enable
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-pushd /opt/test_venv/virtual-fido
-/usr/bin/go run ./cmd/demo pin enable
+# Run in the virtual-fido directory where vault.json is stored
+cd /opt/test_venv/virtual-fido
+"$(dirname "$0")/vfido-demo" pin enable

--- a/src/ansible/roles/passkey/files/vfido_pin_set
+++ b/src/ansible/roles/passkey/files/vfido_pin_set
@@ -5,5 +5,6 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
-pushd /opt/test_venv/virtual-fido
-/usr/bin/go run ./cmd/demo pin set --pin $1
+# Run in the virtual-fido directory where vault.json is stored
+cd /opt/test_venv/virtual-fido
+"$(dirname "$0")/vfido-demo" pin set --pin "$1"

--- a/src/ansible/roles/passkey/files/vfido_reset
+++ b/src/ansible/roles/passkey/files/vfido_reset
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 rm -f /opt/test_venv/virtual-fido/vault.json
-rm -rf /root/.cache/go-build

--- a/src/ansible/roles/passkey/tasks/main.yml
+++ b/src/ansible/roles/passkey/tasks/main.yml
@@ -44,6 +44,21 @@
     with_fileglob:
       - "vfido_*"
 
+  - name: Clone virtual-fido to test_venv
+    git:
+      repo: "https://github.com/bulwarkid/virtual-fido.git"
+      dest: "{{ test_venv }}/virtual-fido"
+      version: 512d8a3fef0e073171a7ef3261f300e8a5e48694
+      clone: yes
+      update: yes
+      depth: 1
+
+  - name: Build vfido-demo binary once to avoid Go compiler fork limits
+    command: go build -ldflags="-s -w" -o {{ test_venv }}/bin/vfido-demo ./cmd/demo
+    args:
+      chdir: "{{ test_venv }}/virtual-fido"
+      creates: "{{ test_venv }}/bin/vfido-demo"
+
   - name: Install vfido systemd service unit file
     copy:
       src: vfido.service
@@ -54,15 +69,5 @@
       name: vfido
       daemon_reload: true
       state: started
-    ignore_errors: yes
-
-  - name: Clone virtual-fido to test_venv
-    git:
-      repo: "https://github.com/bulwarkid/virtual-fido.git"
-      dest: "{{ test_venv }}/virtual-fido"
-      version: 512d8a3fef0e073171a7ef3261f300e8a5e48694
-      clone: yes
-      update: yes
-      depth: 1
 
   when: passkey_support


### PR DESCRIPTION
Replace `go run` with pre-compiled binary to avoid Go compiler fork limits in Testing Farm containers. This eliminates the intermittent "resource temporarily unavailable" errors that caused ~3-4% passkey test failure rate.