### PR TITLE
fix: Update ansible not to use deprecated functionality

### DIFF
--- a/src/ansible/playbook_image_service.yml
+++ b/src/ansible/playbook_image_service.yml
@@ -20,17 +20,17 @@
   gather_facts: no
   roles:
   - ipa
-  - { role: ipasmartcard, when: ansible_os_family == 'RedHat' and virt_smartcard }
+  - { role: ipasmartcard, when: "ansible_facts['os_family'] == 'RedHat' and virt_smartcard" }
 
 - hosts: client
   gather_facts: no
   roles:
   - client
-  - { role: virtsmartcard, when: ansible_os_family == 'RedHat' and virt_smartcard }
-  - { role: ipasmartcard, when: ansible_os_family == 'RedHat' and virt_smartcard }
-  - { role: selenium, when: ansible_os_family == 'RedHat' and selenium_support }
-  - { role: passkey, when: ansible_os_family == 'RedHat' and passkey_support }
-  - { role: gdm, when: ansible_os_family == 'RedHat' and gdm_support }
+  - { role: virtsmartcard, when: "ansible_facts['os_family'] == 'RedHat' and virt_smartcard" }
+  - { role: ipasmartcard, when: "ansible_facts['os_family'] == 'RedHat' and virt_smartcard" }
+  - { role: selenium, when: "ansible_facts['os_family'] == 'RedHat' and selenium_support" }
+  - { role: passkey, when: "ansible_facts['os_family'] == 'RedHat' and passkey_support" }
+  - { role: gdm, when: "ansible_facts['os_family'] == 'RedHat' and gdm_support" }
 
 - hosts: nfs
   gather_facts: no

--- a/src/ansible/roles/common/tasks/main.yml
+++ b/src/ansible/roles/common/tasks/main.yml
@@ -41,11 +41,10 @@
   - not rpm_ostree.stat.exists
 
 - name: Copy common data
-  synchronize:
+  ansible.builtin.copy:
     src: '{{ data_path }}/'
     dest: /var/data/
 
-# synchronize rsync option --chown was ignored for some reason
 - name: Set correct permissions on /var/data
   shell: |
     chown -R root:root /var/data
@@ -88,7 +87,7 @@
 - name: Append or create authorized_keys
   lineinfile:
     dest: "/root/.ssh/authorized_keys"
-    line: "{{ lookup('file', '{{ data_path }}/ssh-keys/root.id_rsa.pub') }}"
+    line: "{{ lookup('file', data_path ~ '/ssh-keys/root.id_rsa.pub') }}"
     create: yes
     state: present
     owner: 'root'

--- a/src/ansible/roles/dns/tasks/main.yml
+++ b/src/ansible/roles/dns/tasks/main.yml
@@ -3,10 +3,10 @@
 
 - name: Add fqdn and short hostname to /etc/hosts
   ansible.builtin.lineinfile:
-    line: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }} \
+    line: "{{ hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] }} \
       {{ inventory_hostname }} {{ inventory_hostname.split('.')[0] }}"
     path: /etc/hosts
-  when: ansible_os_family != "Windows"
+  when: ansible_facts['os_family'] != "Windows"
   become: true
 
 - name: Setup dns (on dns machine)

--- a/src/ansible/roles/dns/tasks/main.yml
+++ b/src/ansible/roles/dns/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Add fqdn and short hostname to /etc/hosts
   ansible.builtin.lineinfile:
-    line: "{{ hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] }} \
+    line: "{{ ansible_facts['default_ipv4']['address'] }} \
       {{ inventory_hostname }} {{ inventory_hostname.split('.')[0] }}"
     path: /etc/hosts
   when: ansible_facts['os_family'] != "Windows"

--- a/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
+++ b/src/ansible/roles/dns/templates/etc.dnsmasq.conf.j2
@@ -48,18 +48,18 @@ srv-host=_ldap._tcp.ldap.test,master.ldap.test,389
 
 # All hosts A record
 {% for host in groups['all'] %}
-{% if hostvars[host].ansible_system == 'Linux' %}
+{% if hostvars[host]['ansible_facts']['system'] == 'Linux' %}
 address=/{{ host }}/{{ hostvars[host]['ansible_facts']['default_ipv4']['address'] }}
-{% elif hostvars[host].ansible_system == 'Win32NT' %}
+{% elif hostvars[host]['ansible_facts']['system'] == 'Win32NT' %}
 address=/{{ host }}/{{ hostvars[host]['ansible_facts']['ip_addresses'][0] }}
 {% endif %}
 {% endfor %}
 
 # All hosts PTR records
 {% for host in groups['all'] %}
-{% if hostvars[host].ansible_system == 'Linux' %}
+{% if hostvars[host]['ansible_facts']['system'] == 'Linux' %}
 ptr-record={{ hostvars[host]['ansible_facts']['default_ipv4']['address'].split('.') | reverse | join(".") }}.in-addr.arpa,{{ host }}
-{% elif hostvars[host].ansible_system == 'Win32NT' %}
+{% elif hostvars[host]['ansible_facts']['system'] == 'Win32NT' %}
 ptr-record={{ hostvars[host]['ansible_facts']['ip_addresses'][0].split('.') | reverse | join(".") }}.in-addr.arpa,{{ host }}
 {% endif %}
 {% endfor %}

--- a/src/ansible/roles/facts/tasks/RedHat.yml
+++ b/src/ansible/roles/facts/tasks/RedHat.yml
@@ -1,9 +1,9 @@
-- name: 'Facts are the same as in CentOS {{ ansible_distribution_major_version }}'
+- name: 'Facts are the same as in CentOS {{ ansible_facts["distribution_major_version"] }}'
   include_tasks: '{{ include_centos }}'
   loop_control:
     loop_var: include_centos
   with_first_found:
-  - files: '{{ "CentOS" | distro_includes(ansible_distribution_major_version) }}'
+  - files: '{{ "CentOS" | distro_includes(ansible_facts["distribution_major_version"]) }}'
 
 - name: Set distribution specific facts
   set_fact:
@@ -14,4 +14,4 @@
 - name: Set distribution specific facts for RHEL 7
   set_fact:
     passkey_support: No
-  when: ansible_distribution_major_version == '7'
+  when: ansible_facts['distribution_major_version'] == '7'

--- a/src/ansible/roles/facts/tasks/main.yml
+++ b/src/ansible/roles/facts/tasks/main.yml
@@ -1,6 +1,6 @@
-- name: 'Include distribution specific tasks [{{ ansible_distribution }} {{ ansible_distribution_major_version }}]'
+- name: 'Include distribution specific tasks [{{ ansible_facts["distribution"] }} {{ ansible_facts["distribution_major_version"] }}]'
   include_tasks: '{{ include_file }}'
   loop_control:
     loop_var: include_file
   with_first_found:
-  - files: '{{ ansible_distribution | distro_includes(ansible_distribution_major_version) }}'
+  - files: '{{ ansible_facts["distribution"] | distro_includes(ansible_facts["distribution_major_version"]) }}'

--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Configure IPA IP address (from ssh)
   set_fact:
-    ipa_ip: "{{ hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] }}"
+    ipa_ip: "{{ ansible_facts['default_ipv4']['address'] }}"
   when: '"meta_ip" not in hostvars[inventory_hostname]'
 
 - name: Prepare IPA facts

--- a/src/ansible/roles/ipa/tasks/main.yml
+++ b/src/ansible/roles/ipa/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Configure IPA IP address (from ssh)
   set_fact:
-    ipa_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+    ipa_ip: "{{ hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] }}"
   when: '"meta_ip" not in hostvars[inventory_hostname]'
 
 - name: Prepare IPA facts

--- a/src/ansible/roles/packages/tasks/RedHat-rpm-ostree.yml
+++ b/src/ansible/roles/packages/tasks/RedHat-rpm-ostree.yml
@@ -33,36 +33,6 @@
   when:
   - "'base_client' in group_names or 'client' in group_names"
 
-# The ansible.posix.rhel_rpm_ostree can only check
-# for presence but can not install anything
-- name: Check sssd packages that should be present and fail when they are missing
-  ansible.posix.rhel_rpm_ostree:
-    name:
-    - adcli
-    - authselect
-    - realmd
-    - sssd-idp
-    - sssd-client
-    - sssd-nfs-idmap
-    - sssd-client
-    - sssd-common
-    - sssd-krb5-common
-    - sssd-common-pac
-    - sssd-ad
-    - sssd-ipa
-    - sssd-krb5
-    - sssd-ldap
-    - sssd-dbus
-    - python3-sssdconfig
-    - sssd-proxy
-    - python3-sss
-    - sssd-tools
-    - sssd
-    - sssd-kcm
-    - sssd-idp
-    - sssd-passkey
-    state: present
-
 # If realmd was installed after polkit it needs to be restarted
 - name: Restart polkit
   ansible.builtin.systemd_service:

--- a/src/ansible/roles/packages/tasks/RedHat10.yml
+++ b/src/ansible/roles/packages/tasks/RedHat10.yml
@@ -1,14 +1,14 @@
 - name: Install EPEL repository
   dnf:
     state: present
-    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm'
+    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts["distribution_major_version"] }}.noarch.rpm'
     disable_gpg_check: yes
   when: extended_packageset
 
 - name: Install EPEL repository (for python3-koji when passkey testing)
   dnf:
     state: present
-    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm'
+    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts["distribution_major_version"] }}.noarch.rpm'
     disable_gpg_check: yes
   when:
     - passkey_support

--- a/src/ansible/roles/packages/tasks/RedHat8.yml
+++ b/src/ansible/roles/packages/tasks/RedHat8.yml
@@ -1,11 +1,11 @@
 - name: Enable idm module
   command: yum module enable idm:DL1 -y
-  when: ansible_distribution_major_version == '8'
+  when: ansible_facts['distribution_major_version'] == '8'
 
 - name: Install EPEL repository
   dnf:
     state: present
-    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm'
+    name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts["distribution_major_version"] }}.noarch.rpm'
     disable_gpg_check: yes
   when: extended_packageset
 

--- a/src/ansible/roles/packages/tasks/main.yml
+++ b/src/ansible/roles/packages/tasks/main.yml
@@ -1,11 +1,11 @@
 - name: Package mode installations
   block:
-    - name: 'Include distribution specific package tasks [{{ ansible_distribution }} {{ ansible_distribution_major_version }}]'
+    - name: 'Include distribution specific package tasks [{{ ansible_facts["distribution"] }} {{ ansible_facts["distribution_major_version"] }}]'
       include_tasks: '{{ include_file }}'
       loop_control:
         loop_var: include_file
       with_first_found:
-      - files: '{{ ansible_distribution | distro_includes(ansible_distribution_major_version) }}'
+      - files: '{{ ansible_facts["distribution"] | distro_includes(ansible_facts["distribution_major_version"]) }}'
 
     - name: 'Clear package manager cache'
       shell: |
@@ -21,11 +21,11 @@
 # This is bandaid to run tests in image mode until dnf can take over and install test dependencies.
 - name: Image mode rpm-ostree installations
   block:
-    - name: 'Include distribution specific tasks (rpm-ostree) [{{ ansible_distribution }} {{ ansible_distribution_major_version }}]'
+    - name: 'Include distribution specific tasks (rpm-ostree) [{{ ansible_facts["distribution"] }} {{ ansible_facts["distribution_major_version"] }}]'
       include_tasks: '{{ include_file }}'
       loop_control:
         loop_var: include_file
       with_first_found:
-      - files: '{{ ansible_distribution | distro_includes(ansible_distribution_major_version, "-rpm-ostree") }}'
+      - files: '{{ ansible_facts["distribution"] | distro_includes(ansible_facts["distribution_major_version"], "-rpm-ostree") }}'
         skip: True
   when: ansible_facts['pkg_mgr'] == "atomic_container"

--- a/src/ansible/roles/passkey/defaults/main.yml
+++ b/src/ansible/roles/passkey/defaults/main.yml
@@ -1,3 +1,3 @@
 test_venv: /opt/test_venv
-#kver: "{{ ansible_kernel | regex_replace('\\.[^.]*$', '') }}"
-kver: "{{ ansible_kernel | regex_replace('\\.' + ansible_architecture + '$', '') }}"
+#kver: "{{ ansible_facts['kernel'] | regex_replace('\\.[^.]*$', '') }}"
+kver: "{{ ansible_facts['kernel'] | regex_replace('\\.' + ansible_facts['architecture'] + '$', '') }}"


### PR DESCRIPTION
Fixes:
- [WARNING]: Jinja constant strings should not contain embedded templates. (ansible-core 2.23)
- [DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. (ansible-core 2.24)
- [DEPRECATION WARNING]: The `ansible.module_utils.common._collections_compat` module is deprecated. (ansible-core 2.24)
- [DEPRECATION WARNING]: Importing 'to_text' from 'ansible.module_utils._text' is deprecated.(ansible-core 2.24)
- The ostree package check was dropped due to deprecation warnings as images for image mode are stable now and contain the expected packages.