### PR TITLE
Fix pytest-mh test environment for RHEL 8.4

### DIFF
--- a/src/ansible/roles/common/tasks/main.yml
+++ b/src/ansible/roles/common/tasks/main.yml
@@ -30,6 +30,19 @@
     mode: 0700
 
 # Backward compatibility symlink
+- name: Check if /data exists as a directory
+  stat:
+    path: /data
+  register: data_stat
+  when: not rpm_ostree.stat.exists
+
+- name: Rename /data to /data.bak if it is an existing directory
+  command: mv /data /data.bak
+  when:
+  - not rpm_ostree.stat.exists
+  - data_stat.stat.exists
+  - data_stat.stat.isdir
+
 - name: Create symlink /data /var/data
   ansible.builtin.file:
     src: '/var/data'

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -68,11 +68,20 @@
       - policycoreutils
       - policycoreutils-python-utils
       - python3-pip
-      - shadow-utils-subid
       - sudo
       - rsync
       - passwd
       disable_gpg_check: yes
+
+  - name: Install shadow-utils-subid (RHEL 8.6+, all other distros)
+    dnf:
+      state: present
+      name:
+      - shadow-utils-subid
+      disable_gpg_check: yes
+    when: not (ansible_facts['distribution'] == 'RedHat' and
+               ansible_facts['distribution_major_version'] == '8' and
+               ansible_facts['distribution_version'] is version('8.6', '<'))
   when: "'base_ground' in group_names"
 
 - name: Install extended set of packages


### PR DESCRIPTION
## Summary

Two fixes to allow pytest-mh tests to run on RHEL 8.4 AWS images.

### 1. packages: skip shadow-utils-subid on RHEL < 8.6

`shadow-utils-subid` was introduced in RHEL 8.6 and is not available on
RHEL 8.4. Split it out from the minimal package set into a separate task
with a version condition so that RHEL 8.4 environments can still install
the rest of the minimal package set successfully.

### 2. common: rename /data to /data.bak if it already exists as a directory

RHEL 8.4 AWS images ship with `/data` as a pre-existing directory.
The `common` role attempts to create a backward compatibility symlink
`/data -> /var/data`, which fails when `/data` is already a directory.
Rename it to `/data.bak` first so the symlink can be created safely.
If `/data` does not exist (as on newer RHEL versions), this is a no-op.

## Test plan

- [x] Verify prep phase succeeds on RHEL 8.4
- [x] Verify tests run on RHEL 8.4 (120 passed, 14 failed due to RHEL 8.4 feature limitations)
- [x] Verify `shadow-utils-subid` is still installed on RHEL 8.6+