### PR TITLE
Re-enable ~-devel images for c8s.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [
-          { base: 'quay.io/centos/centos:stream8', tag: 'centos-8', extra: '', unavailable: 'samba keycloak' },
+          { base: 'quay.io/centos/centos:stream8', tag: 'centos-8', extra: '', unavailable: 'samba' },
           { base: 'quay.io/centos/centos:stream9', tag: 'centos-9', extra: '', unavailable: 'samba' },
           { base: 'quay.io/centos/centos:stream10', tag: 'centos-10', extra: 'centos-latest', unavailable: 'samba' },
         ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [
-          { base: 'quay.io/centos/centos:stream8', tag: 'centos-8', extra: '', unavailable: 'samba keycloak client-devel ipa-devel' },
+          { base: 'quay.io/centos/centos:stream8', tag: 'centos-8', extra: '', unavailable: 'samba keycloak' },
           { base: 'quay.io/centos/centos:stream9', tag: 'centos-9', extra: '', unavailable: 'samba' },
           { base: 'quay.io/centos/centos:stream10', tag: 'centos-10', extra: 'centos-latest', unavailable: 'samba' },
         ]

--- a/src/ansible/roles/facts/tasks/CentOS8.yml
+++ b/src/ansible/roles/facts/tasks/CentOS8.yml
@@ -3,12 +3,13 @@
 - name: 'Facts are the same as in Fedora'
   include_tasks: 'Fedora.yml'
 
-# c8s-build koji has modular RPMs without modular metadata (breaks IPA);
+# c8s-build koji has modular RPMs without modular metadata; packages/CentOS8.yml
+# enables the repo with module_hotfixes=true so IPA/~-devel can still install.
 # epel-playground-debuginfo is gone on EL8; samba DC is UNAVAILABLE so it
 # comes from Fedora quay image and C8S IPA cannot establish a trust with it
 - name: Set distribution specific facts
   set_fact:
     passkey_support: false
     debuginfo: false
-    buildroot: false
+    buildroot: true
     trust_ipa_samba: false

--- a/src/ansible/roles/packages/tasks/CentOS8.yml
+++ b/src/ansible/roles/packages/tasks/CentOS8.yml
@@ -14,7 +14,9 @@
       group: root
       mode: 0644
     with_items:
-    - {name: 'buildroot', url: 'https://kojihub.stream.centos.org/kojifiles/repos/c8s-build/latest/$basearch'}
+    # c8s-build ships modular RPMs without modulemd; module_hotfixes lets
+    # dnf install them anyway (needed for IPA and ~-devel deps).
+    - {name: 'buildroot', url: 'https://kojihub.stream.centos.org/kojifiles/repos/c8s-build/latest/$basearch', module_hotfixes: true}
     - {name: 'crb', url: 'http://vault.centos.org/centos/8-stream/PowerTools/$basearch/os/'}
     when: buildroot
 

--- a/src/ansible/roles/packages/tasks/CentOS8.yml
+++ b/src/ansible/roles/packages/tasks/CentOS8.yml
@@ -31,5 +31,15 @@
       dnf module enable -y idm:DL1
   when: "'base_ground' in group_names"
 
+- name: Install java-21-openjdk-headless for Keycloak
+  block:
+  - name: Install Keycloak dependencies
+    dnf:
+      state: present
+      allowerasing: true
+      name:
+      - java-21-openjdk-headless
+  when: "'base_keycloak' in group_names"
+
 - name: 'Packages are the same as in Fedora'
   include_tasks: 'Fedora.yml'

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -312,11 +312,21 @@
       state: present
       allowerasing: true
       name:
-      - java-25-openjdk-headless
       - openssl
       - unzip
       - curl
       - jq
+
+  - name: Check installed packages
+    ansible.builtin.package_facts:
+
+  - name: Install java-25-openjdk-headless
+    dnf:
+      state: present
+      allowerasing: true
+      name:
+      - java-25-openjdk-headless
+    when: "'java-21-openjdk-headless' not in ansible_facts.packages"
   when: "'base_keycloak' in group_names"
 
 - name: Install additional packages for client development image

--- a/src/ansible/roles/packages/templates/repo
+++ b/src/ansible/roles/packages/templates/repo
@@ -4,3 +4,6 @@ baseurl={{ item.url }}
 enabled=1
 gpgcheck=0
 skip_if_unavailable=True
+{%- if item.module_hotfixes | default(false) %}
+module_hotfixes=true
+{%- endif %}

--- a/src/ansible/roles/packages/templates/repo
+++ b/src/ansible/roles/packages/templates/repo
@@ -4,6 +4,6 @@ baseurl={{ item.url }}
 enabled=1
 gpgcheck=0
 skip_if_unavailable=True
-{%- if item.module_hotfixes | default(false) %}
+{% if item.module_hotfixes | default(false) %}
 module_hotfixes=true
-{%- endif %}
+{% endif %}


### PR DESCRIPTION
Work around broken buildroot repository with missing modular metadata for c8s.
Partially revert change to java-25-openjdk-headless for keycloak on c8s keeping java-21-openjdk-headless.
