### PR TITLE
Fix STIG tier2: ignore passkey setup errors on hardened systems

### DIFF
--- a/src/ansible/roles/packages/tasks/CentOS10.yml
+++ b/src/ansible/roles/packages/tasks/CentOS10.yml
@@ -53,6 +53,7 @@
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"
+  ignore_errors: yes
 
 - name: Install packages for usbip needed for virtual passkey testing
   dnf:
@@ -68,3 +69,4 @@
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"
+  ignore_errors: yes

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -294,6 +294,7 @@
       - nmap-ncat
       - git
     when: passkey_support
+    ignore_errors: yes
   when: "'base_client' in group_names or 'client' in group_names or 'base_ipa' in group_names or 'ipa' in group_names"
 
 - name: Install usbip on the client
@@ -304,6 +305,7 @@
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"
+  ignore_errors: yes
 
 - name: Install packages for Keycloak base image
   block:

--- a/src/ansible/roles/packages/tasks/RedHat10.yml
+++ b/src/ansible/roles/packages/tasks/RedHat10.yml
@@ -13,6 +13,7 @@
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"
+  ignore_errors: yes
 
 - name: Install packages for usbip needed for virtual passkey testing
   dnf:
@@ -28,6 +29,7 @@
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"
+  ignore_errors: yes
 
 - name: 'Packages are the same as in Fedora'
   include_tasks: 'Fedora.yml'

--- a/src/ansible/roles/passkey/tasks/main.yml
+++ b/src/ansible/roles/passkey/tasks/main.yml
@@ -18,6 +18,7 @@
       path: /opt/random.c
       state: absent
   when: passkey_support
+  ignore_errors: yes
 
 - name: Configure vfido wrapper for virtual-fido to support passkeys
   block:
@@ -75,3 +76,4 @@
     ignore_errors: true
 
   when: passkey_support
+  ignore_errors: yes


### PR DESCRIPTION
STIG tier2 jobs fail during Ansible setup because passkey-related packages (umockdev, usbip) are not GPG-signed, and STIG-hardened systems enforce gpgcheck=1. This blocks the entire job even though STIG jobs do not run passkey tests (-k="not passkey and not smartcard").

Example error:

Failed to validate GPG signature for umockdev-0.19.1-2.el10.x86_64: Added ignore_errors: yes to passkey package install tasks in Fedora.yml and RedHat10.yml. This allows the setup to continue when passkey packages fail to install, unblocking STIG and other jobs that do not need them.

The passkey role's Build random.so task then fails with gcc: command not found on STIG systems because the earlier package install (which includes gcc) was silently ignored. The vfido wrapper block would similarly fail due to missing go. CentOS10.yml passkey tasks were also missing ignore_errors.

Added ignore_errors: yes to:
  - Both blocks in passkey/tasks/main.yml (build random.so, configure vfido)
  - Both passkey tasks in packages/tasks/CentOS10.yml (EPEL, usbip packages)