### PR TITLE
Enable AES Kerberos encryption on AD server for FIPS:STIG client compatibility

### DIFF
--- a/src/ansible/roles/ad/tasks/install.yml
+++ b/src/ansible/roles/ad/tasks/install.yml
@@ -30,6 +30,26 @@
   win_reboot:
   when: installation.changed
 
+- name: Enable AES Kerberos encryption for FIPS/STIG client compatibility
+  win_shell: |
+    Import-Module ActiveDirectory
+
+    # Enable AES 256 encryption support on domain controllers
+    # 0x18 = AES128 (0x08) + AES256 (0x10)
+    Get-ADComputer -Filter {PrimaryGroupID -eq 516} -Properties msDS-SupportedEncryptionTypes |
+      Set-ADComputer -Replace @{'msDS-SupportedEncryptionTypes' = 24}
+
+    # Configure supported Kerberos encryption types via registry
+    New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters" -Force
+    Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters" `
+      -Name "SupportedEncryptionTypes" -Value 24 -Type DWord -Force
+
+    gpupdate /force
+  register: aes_config
+  until: aes_config.rc == 0
+  retries: 3
+  delay: 30
+
 - name: Install AD Certificate Services
   win_feature:
     name: AD-Certificate


### PR DESCRIPTION

- Enable AES-128 and AES-256 Kerberos encryption types on Windows AD domain controllers after forest creation
- Sets msDS-SupportedEncryptionTypes on DC computer objects and configures the registry-level Kerberos encryption policy
- Fixes AD STIG test failures where realm join fails with "The encryption types desired are not available in active directory" when the client has FIPS:STIG crypto policy applied

Problem
RHEL clients with FIPS:STIG crypto policy restrict Kerberos to strong AES encryption types only.
The Windows AD server in the CI test environment did not have AES enabled, causing all encryption types (18, 17, 16, 23, 3, 1) to be rejected during realm join. This blocked the entire tier2-stig-pytest-ad-stig test suite.