### PR TITLE
Add stig_enabled flag

### DIFF
--- a/src/ansible/playbook_vm.yml
+++ b/src/ansible/playbook_vm.yml
@@ -8,6 +8,7 @@
   ansible.builtin.import_playbook: playbook_image_base.yml
   vars:
     passkey_support: "{{ override_passkey_support | default('no') | bool }}"
+    stig_enabled: "{{ override_stig_enabled | default('no') | bool }}"
     user_regular_uid: 1024
     ansible_become: yes
     extended_packageset: "{{ override_extended_packageset | default('no') | bool }}"
@@ -18,6 +19,7 @@
   ansible.builtin.import_playbook: playbook_image_service.yml
   vars:
     passkey_support: "{{ override_passkey_support | default('no') | bool }}"
+    stig_enabled: "{{ override_stig_enabled | default('no') | bool }}"
     user_regular_uid: 1024
     ansible_become: yes
     join_ad: "{{ override_join_ad | default('no') | bool }}"

--- a/src/ansible/roles/packages/tasks/CentOS10.yml
+++ b/src/ansible/roles/packages/tasks/CentOS10.yml
@@ -50,6 +50,12 @@
     dnf:
       name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
       state: present
+  # Tolerate failure on STIG-hardened systems where packages may be unsigned
+  rescue:
+  - name: Fail EPEL setup if not STIG
+    fail:
+      msg: "EPEL setup for passkey failed and stig_enabled is not set"
+    when: not stig_enabled | default(false) | bool
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"
@@ -65,6 +71,11 @@
     - systemd-devel
     - libtool
     - python3-koji
+  register: usbip_deps
+  # Tolerate failure on STIG-hardened systems where packages may be unsigned
+  failed_when:
+    - usbip_deps is failed
+    - not stig_enabled | default(false) | bool
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"

--- a/src/ansible/roles/packages/tasks/Fedora.yml
+++ b/src/ansible/roles/packages/tasks/Fedora.yml
@@ -294,6 +294,11 @@
       - go
       - nmap-ncat
       - git
+    register: passkey_packages
+    # Tolerate failure on STIG-hardened systems where packages may be unsigned
+    failed_when:
+      - passkey_packages is failed
+      - not stig_enabled | default(false) | bool
     when: passkey_support
   when: "'base_client' in group_names or 'client' in group_names or 'base_ipa' in group_names or 'ipa' in group_names"
 
@@ -302,6 +307,11 @@
     state: present
     name:
     - usbip
+  register: usbip_install
+  # Tolerate failure on STIG-hardened systems where packages may be unsigned
+  failed_when:
+    - usbip_install is failed
+    - not stig_enabled | default(false) | bool
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"

--- a/src/ansible/roles/packages/tasks/RedHat10.yml
+++ b/src/ansible/roles/packages/tasks/RedHat10.yml
@@ -10,6 +10,11 @@
     state: present
     name: 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts["distribution_major_version"] }}.noarch.rpm'
     disable_gpg_check: yes
+  register: epel_passkey
+  # Tolerate failure on STIG-hardened systems where packages may be unsigned
+  failed_when:
+    - epel_passkey is failed
+    - not stig_enabled | default(false) | bool
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"
@@ -25,6 +30,11 @@
     - systemd-devel
     - libtool
     - python3-koji
+  register: usbip_deps
+  # Tolerate failure on STIG-hardened systems where packages may be unsigned
+  failed_when:
+    - usbip_deps is failed
+    - not stig_enabled | default(false) | bool
   when:
     - passkey_support
     - "'base_client' in group_names or 'client' in group_names"

--- a/src/ansible/roles/passkey/tasks/main.yml
+++ b/src/ansible/roles/passkey/tasks/main.yml
@@ -17,6 +17,12 @@
     file:
       path: /opt/random.c
       state: absent
+  # Tolerate failure on STIG-hardened systems where gcc/openssl-devel may be missing
+  rescue:
+  - name: Fail passkey build if not STIG
+    fail:
+      msg: "Passkey build failed and stig_enabled is not set"
+    when: not stig_enabled | default(false) | bool
   when: passkey_support
 
 - name: Configure vfido wrapper for virtual-fido to support passkeys
@@ -74,4 +80,10 @@
     command: modprobe vhci_hcd
     ignore_errors: true
 
+  # Tolerate failure on STIG-hardened systems where git/go may be missing
+  rescue:
+  - name: Fail vfido setup if not STIG
+    fail:
+      msg: "Vfido setup failed and stig_enabled is not set"
+    when: not stig_enabled | default(false) | bool
   when: passkey_support


### PR DESCRIPTION
 - Add stig_enabled variable to playbook_vm.yml following the same pattern as passkey_support, defaults to false Pass override_stig_enabled: true as extra_vars on the playbook_vm.yml step in STIG metadata:
  - playbook: ../sssd-ci-containers/src/ansible/playbook_vm.yml extra_vars: override_stig_enabled: true