### PR TITLE
ci: Workaround broken Ubuntu 24.04 podman version

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -26,7 +26,7 @@ runs:
     shell: bash
     run: |
       sudo apt-get update
-      sudo apt-get install -y podman docker-compose
+      sudo apt-get install -y docker-compose
 
   - name: Print package versions
     shell: bash

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -26,7 +26,7 @@ runs:
     run: |
       set -ex
       sudo apt-get update
-      sudo apt-get install -y podman docker-compose
+      sudo apt-get install -y docker-compose
 
   - name: Start podman socket
     shell: bash


### PR DESCRIPTION
With the current GitHub Actions Ubuntu 24.04 runner, exec-ing into a running container often hangs.  This started happening after the runner image was upgraded.

This was reported as a actions/runner-images issue here: https://github.com/actions/runner-images/issues/14604

Instead of waiting for the image fix, avoid installing the broken podman, the good version is already installed in the image.  Suggested as a workaround at the above issue link.