### PR TITLE
setup: create wrapper for docker-compose

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -28,6 +28,15 @@ runs:
       sudo apt-get update
       sudo apt-get install -y docker-compose
 
+      # Create wrapper script for docker-compose that uses podman compose
+      # /usr/bin/docker-compose is not available on ubuntu-26-04 even when
+      # installed
+      if ! command -v docker-compose &> /dev/null; then
+        echo -e '#!/bin/bash\nexec podman compose "$@"' | sudo tee /usr/bin/docker-compose > /dev/null
+        sudo chmod +x /usr/bin/docker-compose
+        docker-compose --help
+      fi
+
   - name: Start podman socket
     shell: bash
     run: |


### PR DESCRIPTION
The docker-compose command is not directly available in ubuntu-26-04
image. Creating a wrapper around it to avoid changing scripts for now.
